### PR TITLE
Prevent the backend daemon from crashing due to bitchute datasource errors

### DIFF
--- a/datasources/bitchute/search_bitchute.py
+++ b/datasources/bitchute/search_bitchute.py
@@ -306,9 +306,6 @@ class SearchBitChute(Search):
 
             video_page = video_session.get(video["url"])
 
-            if "404 - Page not found" in video_page.text:
-                video["category"] = "deleted"
-                return (video, [])
             if "This video is unavailable as the contents have been deemed potentially illegal" in video_page.text:
                 video["category"] = "moderated-illegal"
                 return (video, [])

--- a/datasources/bitchute/search_bitchute.py
+++ b/datasources/bitchute/search_bitchute.py
@@ -239,6 +239,11 @@ class SearchBitChute(Search):
                 else:
                     num_items += 1
 
+                # note: deleted videos will have a published date of 'None'. To
+                # avoid crashing the backend the easiest way is to set it to something
+                # that is obviously not a valid date in this context.
+                if video_data["published"] is None:
+                    video_data["published"] = "1970-01-01"
                 # this is only included as '5 months ago' and so forth, not exact date
                 # so use dateparser to at least approximate the date
                 dt = dateparser.parse(video_data["published"])
@@ -300,6 +305,10 @@ class SearchBitChute(Search):
             video_session = requests.session()
 
             video_page = video_session.get(video["url"])
+
+            if "404 - Page not found" in video_page.text:
+                video["category"] = "deleted"
+                return (video, [])
             if "This video is unavailable as the contents have been deemed potentially illegal" in video_page.text:
                 video["category"] = "moderated-illegal"
                 return (video, [])


### PR DESCRIPTION
We noticed that the backend daemon would occasionally crash when it
encounters a video that has been deleted. The published date for
deleted videos returned by the bitchute api is currently 'None' which
becomes a problem for dateparse.

As a workaround to this the date will be set to something that is
obviously wrong ( 1970-01-01 00:00:00 ) before it will be parsed to fix
the basic search.

For the detailed search a video should be skipped if the returned page
contains the '404 - this page cannot be found' text.

These two changes should fix the issue mentioned in #140

Cheers