### PR TITLE
change to migrate to install nltk and spacy packages

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -67,7 +67,7 @@ if [ "$(version "$CURRENT")" -ge "$(version "$TARGET")" ]; then
     echo "Version is up to date"
 else
     echo "Running migrations"
-  #  python3 helper-scripts/migrate.py --yes
+    python3 helper-scripts/migrate.py --yes
 fi
 
 # Inform user of admin password if created

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -67,7 +67,7 @@ if [ "$(version "$CURRENT")" -ge "$(version "$TARGET")" ]; then
     echo "Version is up to date"
 else
     echo "Running migrations"
-    python3 helper-scripts/migrate.py --yes
+  #  python3 helper-scripts/migrate.py --yes
 fi
 
 # Inform user of admin password if created

--- a/helper-scripts/migrate.py
+++ b/helper-scripts/migrate.py
@@ -198,6 +198,28 @@ if current_version_file.exists():
 	current_version_file.unlink()
 shutil.copy(target_version_file, ".current-version")
 
+
+# ---------------------------------------------
+#        Check for and install packages
+# ---------------------------------------------
+# NLTK
+import nltk
+try:
+	nltk.data.find('tokenizers/punkt')
+except LookupError:
+	nltk.download('punkt')
+try:
+	nltk.data.find('corpora/wordnet')
+except LookupError:
+	nltk.download("wordnet")
+
+# Spacy 
+import spacy
+try:
+	spacy.load('en_core_web_sm')
+except IOError:
+	spacy.cli.download('en_core_web_sm')
+
 print("\nMigration scripts finished.")
 print("It is recommended to re-generate your Sphinx configuration and index files to account for database updates.")
 print("You can now safely restart 4CAT.\n")

--- a/helper-scripts/migrate.py
+++ b/helper-scripts/migrate.py
@@ -213,12 +213,12 @@ try:
 except LookupError:
 	nltk.download("wordnet")
 
-# Spacy 
-import spacy
-try:
-	spacy.load('en_core_web_sm')
-except IOError:
-	spacy.cli.download('en_core_web_sm')
+# # Spacy
+# import spacy
+# try:
+# 	spacy.load('en_core_web_sm')
+# except IOError:
+# 	spacy.cli.download('en_core_web_sm')
 
 print("\nMigration scripts finished.")
 print("It is recommended to re-generate your Sphinx configuration and index files to account for database updates.")

--- a/helper-scripts/migrate.py
+++ b/helper-scripts/migrate.py
@@ -213,13 +213,6 @@ try:
 except LookupError:
 	nltk.download("wordnet")
 
-# # Spacy
-# import spacy
-# try:
-# 	spacy.load('en_core_web_sm')
-# except IOError:
-# 	spacy.cli.download('en_core_web_sm')
-
 print("\nMigration scripts finished.")
 print("It is recommended to re-generate your Sphinx configuration and index files to account for database updates.")
 print("You can now safely restart 4CAT.\n")

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,6 @@ unix_packages = [
 	"python-daemon==2.3.0"
 ]
 
-# # Dependency urls
-# dependency_links=[
-#         "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm",
-#     ]
-
 if os.name != "nt":
 	packages = packages + unix_packages
 
@@ -76,5 +71,4 @@ setup(
 	packages=['backend', 'webtool', 'datasources'],
 	python_requires='>=3.7',
 	install_requires=packages,
-	# dependency_links=dependency_links,
 )

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,18 @@ packages = [
 	"svgwrite==1.3.1",
 	"Telethon==1.10.6",
 	"Werkzeug==0.15.5",
+	"en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm"
 ]
 
 # Some packages don't run on Windows
 unix_packages = [
 	"python-daemon==2.3.0"
 ]
+
+# # Dependency urls
+# dependency_links=[
+#         "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm",
+#     ]
 
 if os.name != "nt":
 	packages = packages + unix_packages
@@ -69,5 +75,6 @@ setup(
 	url="https://oilab.eu",
 	packages=['backend', 'webtool', 'datasources'],
 	python_requires='>=3.7',
-	install_requires=packages
+	install_requires=packages,
+	# dependency_links=dependency_links,
 )


### PR DESCRIPTION
This could fix Issue #157 , but I do not really like loading the spacy package first. And I am not sure migrate is the best place for this, but it is the only 'install' package we use for a direct installation (beyond the requirements doc).

For the docker installation, it runs a setup file every time you start it up and on the first installation it installs these packages. If we merge this, that will not be necessary since it also runs migrate.py to check for updates (which I am actually not sure is a best practice as we can control docker releases more directly once we load it into their repository).