### PR TITLE
Relative paths for result on new dataset page. Fixes 209

### DIFF
--- a/webtool/static/js/fourcat.js
+++ b/webtool/static/js/fourcat.js
@@ -372,7 +372,7 @@ const query = {
 					clearInterval(query.poll_interval);
 					let keyword = json.label;
 
-					$('#query-results').append('<li><a href="/results/' + json.key + '">' + keyword + ' (' + json.rows + ' items)</a></li>');
+					$('#query-results').append('<li><a href="../results/' + json.key + '">' + keyword + ' (' + json.rows + ' items)</a></li>');
 					query.enable_form();
 					alert('Query for \'' + keyword + '\' complete!');
 				} else {


### PR DESCRIPTION
A smol bugfix by just making the injected URLs relative. Fixes #209. Should work also on installations where 4CAT is installed in root path at */*.

![](https://i.kym-cdn.com/entries/icons/original/000/032/265/smol.jpg)