### PR TITLE
Private datasets

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-1.24
+1.25
 
 This file should not be modified. It is used by 4CAT to determine whether it
 needs to run migration scripts to e.g. update the database structure to a more

--- a/backend/abstract/processor.py
+++ b/backend/abstract/processor.py
@@ -230,8 +230,15 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 				self.log.info("Not running follow-up processor of type %s for dataset %s, no input data for follow-up" % (next_type, self.dataset.key))
 
 			elif next_type in available_processors:
-				next_analysis = DataSet(parameters=next_parameters, type=next_type, db=self.db, parent=self.dataset.key,
-										extension=available_processors[next_type].extension)
+				next_analysis = DataSet(
+					parameters=next_parameters,
+					type=next_type,
+					db=self.db,
+					parent=self.dataset.key,
+					extension=available_processors[next_type].extension,
+					is_private=self.dataset.is_private,
+					owner=self.dataset.owner
+				)
 				self.queue.add_job(next_type, remote_id=next_analysis.key)
 			else:
 				self.log.warning("Dataset %s (of type %s) wants to run processor %s next, but it is incompatible" % (self.dataset.key, self.type, next_type))

--- a/backend/database.sql
+++ b/backend/database.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS datasets (
   key               text,
   type              text DEFAULT 'search',
   key_parent        text DEFAULT '',
+  owner             VARCHAR DEFAULT 'anonymous',
   query             text,
   job               integer DEFAULT 0,
   parameters        text,
@@ -40,6 +41,7 @@ CREATE TABLE IF NOT EXISTS datasets (
   status            text,
   num_rows          integer DEFAULT 0,
   is_finished       boolean DEFAULT FALSE,
+  is_private        boolean DEFAULT TRUE,
   software_version  text,
   software_file     text DEFAULT '',
   annotation_fields text DEFAULT ''

--- a/backend/workers/api.py
+++ b/backend/workers/api.py
@@ -239,7 +239,7 @@ class InternalAPI(BasicWorker):
 						"is_recurring": (int(job["interval"]) > 0),
 						"is_maybe_crashed": job["timestamp_claimed"] > 0 and not worker,
 						"dataset_key": worker.dataset.key if hasattr(worker, "dataset") else None,
-						"dataset_user": worker.dataset.parameters.get("user", None) if hasattr(worker, "dataset") else None,
+						"dataset_user": worker.dataset.owner if hasattr(worker, "dataset") else None,
 						"dataset_parent_key": worker.dataset.top_parent().key if hasattr(worker, "dataset") else None,
 						"timestamp_queued": job["timestamp"],
 						"timestamp_claimed": job["timestamp_lastclaimed"]

--- a/helper-scripts/migrate/migrate-1.24-1.25.py
+++ b/helper-scripts/migrate/migrate-1.24-1.25.py
@@ -1,0 +1,42 @@
+# Add 'is_deactivated' column to user table
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)) + "'/../..")
+from common.lib.database import Database
+from common.lib.logger import Logger
+
+import config
+
+log = Logger(output=True)
+db = Database(logger=log, dbname=config.DB_NAME, user=config.DB_USER, password=config.DB_PASSWORD, host=config.DB_HOST,
+              port=config.DB_PORT, appname="4cat-migrate")
+
+print("  Checking if datasets table has a column 'is_private'...")
+has_column = db.fetchone("SELECT COUNT(*) AS num FROM information_schema.columns WHERE table_name = 'datasets' AND column_name = 'is_private'")
+if has_column["num"] == 0:
+    print("  ...No, adding.")
+    db.execute("ALTER TABLE datasets ADD COLUMN is_private BOOLEAN DEFAULT TRUE")
+    db.commit()
+
+    # make existing datasets all non-private, as they were before
+    db.execute("UPDATE datasets SET is_private = FALSE")
+    db.commit()
+else:
+    print("  ...Yes, nothing to update.")
+
+print("  Checking if datasets table has a column 'owner'...")
+has_column = db.fetchone("SELECT COUNT(*) AS num FROM information_schema.columns WHERE table_name = 'datasets' AND column_name = 'owner'")
+if has_column["num"] == 0:
+    print("  ...No, adding.")
+    db.execute("ALTER TABLE datasets ADD COLUMN owner VARCHAR DEFAULT 'anonymous'")
+    db.commit()
+
+    # make existing datasets all non-private, as they were before
+    db.execute("UPDATE datasets SET owner = parameters::json->>'user' WHERE parameters::json->>'user' IS NOT NULL")
+    db.commit()
+else:
+    print("  ...Yes, nothing to update.")
+
+
+print("  Done!")

--- a/webtool/api_standalone.py
+++ b/webtool/api_standalone.py
@@ -138,7 +138,14 @@ def process_standalone(processor):
 		return error(402, error="Input is empty")
 
 	# ok, valid input!
-	temp_dataset = DataSet(extension="csv", type="standalone", parameters={"user": current_user.get_id(), "after": [processor]}, db=db)
+	temp_dataset = DataSet(
+		extension="csv",
+		type="standalone",
+		parameters={"next": [processor]},
+		db=db,
+		owner=current_user.get_id(),
+		is_private=True
+	)
 	temp_dataset.finish(len(input))
 
 	# make sure the file is deleted later, whichever way this request is

--- a/webtool/lib/user.py
+++ b/webtool/lib/user.py
@@ -78,6 +78,34 @@ class User:
 		else:
 			return User(user)
 
+	def can_access_dataset(self, dataset):
+		"""
+		Check if this user should be able to access a given dataset.
+
+		This depends mostly on the dataset's owner, which should match the
+		user if the dataset is private. If the dataset is not private, or
+		if the user is an admin or the dataset is private but assigned to
+		an anonymous user, the dataset can be accessed.
+
+		:param dataset:  The dataset to check access to
+		:return bool:
+		"""
+		if not dataset.is_private:
+			return True
+
+		elif self.is_admin():
+			return True
+
+		elif self.get_id() == dataset.owner:
+			return True
+
+		elif dataset.owner == "anonymous":
+			return True
+
+		else:
+			return False
+
+
 	def __init__(self, data, authenticated=False):
 		"""
 		Instantiate user object

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -46,9 +46,18 @@
                         appropriate.</p>
                     <div class="form-element">
                         <label for="data-pseudonymise">Pseudonymise:</label>
-                        <div class="filter-parameters" id="board-filter">
+                        <div class="filter-parameters">
                             <label><input type="checkbox" checked="checked" name="pseudonymise" id="data-pseudonymise"> Replace author names with hashed values</label>
                         </div>
+                    </div>
+                    <div class="form-element">
+                        <label for="data-make-private">Make private:</label>
+                        <div class="filter-parameters">
+                            <label><input type="checkbox" name="make-private" id="data-make-private"> Make dataset private</label>
+                        </div>
+
+                        <button class="tooltip-trigger" aria-controls="tooltip-dataset-private" aria-label="Extended help for option">?</button>
+                        <p role="tooltip" id="tooltip-dataset-private">This will only hide your dataset from other users. It will NOT encrypt your data and instance maintainers will still be able to view it. If you are working with sensitive data, you should consider running your own 4CAT instance.</p>
                     </div>
                     <div class="form-element">
                         <label for="dataset-label">Dataset name:</label>

--- a/webtool/templates/result-child.html
+++ b/webtool/templates/result-child.html
@@ -111,7 +111,7 @@
                 </li>
                 {% endif %}
                 {% endif %}
-                {% if current_user.is_authenticated and (current_user.get_id() == dataset.parameters.user or current_user.is_admin or item.parameters.userparameters.user == current_user.get_id()) %}
+                {% if current_user.is_authenticated and (current_user.get_id() == dataset.owner or current_user.is_admin or item.owner == current_user.get_id()) %}
                 <li>
                     <a class="property-badge delete-link tooltip-trigger" href="{{ url_for('delete_dataset_interactive', key=item.key) }}" data-confirm-action="delete this dataset"><i class="fa fa-fw fa-times" aria-hidden="true"></i> <span class="sr-only">Delete this analysis</span></a>
                     <p role="tooltip" id="tooltip-delete-{{ item.key }}" aria-hidden="true">{% if not item.is_finished %}Cancel and d{% else %}D{% endif %}elete this analysis and any underlying analyses</p>

--- a/webtool/templates/result-details.html
+++ b/webtool/templates/result-details.html
@@ -13,6 +13,9 @@
                       <li><a href="{{ url_for('explorer_dataset', key=dataset.key) }}" class="explorer-dataset" target="__blank"><i class="fas fa-binoculars" aria-hidden="true"></i> Explore & annotate</a></li>
                     {% endif %}
                     <li><a href="{{ url_for('toggle_favourite_interactive', key=dataset.key) }}" class="toggle-favourites"><i class="fa{% if is_favourite %}r{% else %}s{% endif %} fa-star" aria-hidden="true"></i> {% if is_favourite %}Delete from{% else %}Add to{% endif %} favourites</a></li>
+                    {% if current_user.is_authenticated and (current_user.is_admin() or current_user.get_id() == dataset.owner) %}
+                        <li><a href="{{ url_for('toggle_private_interactive', key=dataset.key) }}" class="toggle-private"><i class="fas fa-lock{% if dataset.is_private %}-open{% endif %}" aria-hidden="true"></i> {% if dataset.is_private %}Make public{% else %}Make private{% endif %}</a></li>
+                    {% endif %}
                     <li><a href="{{ url_for('show_result', key=dataset.key) }}"><i class="fas fa-link" aria-hidden="true"></i> Permalink</a></li>
                     {% if current_user.get_id() == dataset.parameters.user or current_user.is_admin() %}
                         <li><a href="{{ url_for('delete_dataset_interactive', key=dataset.key) }}" class="confirm-first" data-confirm-action="delete this dataset"><i class="fas fa-trash-alt" aria-hidden="true"></i> Delete dataset</a></li>
@@ -48,10 +51,10 @@
                 <dd>{{ dataset.timestamp|datetime(fmt="%d %b %Y, %H:%M") }}</dd>
             </div>
 
-        {% if current_user.is_authenticated and current_user.is_admin() and dataset.parameters.user %}
+        {% if current_user.is_authenticated and current_user.is_admin() and dataset.owner %}
             <div class="fullwidth">
                 <dt>Queued by</dt>
-                <dd>{{ dataset.parameters.user }}</dd>
+                <dd>{{ dataset.owner }}</dd>
             </div>
         {% endif %}
 

--- a/webtool/templates/result-details.html
+++ b/webtool/templates/result-details.html
@@ -17,7 +17,7 @@
                         <li><a href="{{ url_for('toggle_private_interactive', key=dataset.key) }}" class="toggle-private"><i class="fas fa-lock{% if dataset.is_private %}-open{% endif %}" aria-hidden="true"></i> {% if dataset.is_private %}Make public{% else %}Make private{% endif %}</a></li>
                     {% endif %}
                     <li><a href="{{ url_for('show_result', key=dataset.key) }}"><i class="fas fa-link" aria-hidden="true"></i> Permalink</a></li>
-                    {% if current_user.get_id() == dataset.parameters.user or current_user.is_admin %}
+                    {% if current_user.get_id() == dataset.owner or current_user.is_admin %}
                         <li><a href="{{ url_for('delete_dataset_interactive', key=dataset.key) }}" class="confirm-first" data-confirm-action="delete this dataset"><i class="fas fa-trash-alt" aria-hidden="true"></i> Delete dataset</a></li>
                         <li><a href="{{ url_for('restart_dataset', key=dataset.key) }}" class="confirm-first" data-confirm-method="POST" data-confirm-action="delete all results for this dataset, including processor results, and re-run the query"><i class="fas fa-sync-alt" aria-hidden="true"></i> Re-run dataset</a></li>
                     {% endif %}

--- a/webtool/templates/result-metadata.html
+++ b/webtool/templates/result-metadata.html
@@ -1,3 +1,8 @@
+{% if dataset.is_private %}
+    <i class="fa fa-lock tooltip-trigger" aria-hidden="true" aria-controls="tooltip-{{ dataset.key }}-private"></i> <span class="sr-only">This dataset is private and can only be viewed by your user and instance maintainers</span>
+    <span role="tooltip" aria-hidden="true" id="tooltip-{{ dataset.key }}-private">This dataset is private and can only be viewed by your user and instance maintainers</span>
+{% endif %}
+
 {% if "pseudonymise" in dataset.parameters and dataset.parameters.pseudonymise %}
     <i class="fa fa-user-secret tooltip-trigger" aria-hidden="true" aria-controls="tooltip-{{ dataset.key }}-pseudonymised"></i> <span class="sr-only">Usernames have been pseudonymised</span>
     <span role="tooltip" aria-hidden="true" id="tooltip-{{ dataset.key }}-pseudonymised">Usernames have been pseudonymised</span>

--- a/webtool/views.py
+++ b/webtool/views.py
@@ -7,6 +7,9 @@ import re
 import csv
 import json
 import glob
+
+import flask
+
 import config
 import markdown
 
@@ -21,7 +24,7 @@ from flask_login import login_required, current_user
 from webtool import app, db, log
 from webtool.lib.helpers import Pagination, error
 
-from webtool.api_tool import delete_dataset, toggle_favourite, queue_processor, nuke_dataset
+from webtool.api_tool import delete_dataset, toggle_favourite, toggle_private, queue_processor, nuke_dataset
 
 from common.lib.dataset import DataSet
 from common.lib.queue import JobQueue
@@ -271,6 +274,9 @@ def get_mapped_result(key):
 	except TypeError:
 		abort(404)
 
+	if dataset.is_private and not (current_user.is_admin() or dataset.owner == current_user.get_id()):
+		return error(403, error="This dataset is private.")
+
 	if dataset.get_extension() == ".csv":
 		# if it's already a csv, just return the existing file
 		return url_for(get_result, query_file=dataset.get_results_path().name)
@@ -333,7 +339,7 @@ def show_results(page):
 		depth = "own"
 
 	if depth == "own":
-		where.append("parameters::json->>'user' = %s")
+		where.append("owner = %s")
 		replacements.append(current_user.get_id())
 
 	if depth == "favourites":
@@ -344,6 +350,10 @@ def show_results(page):
 		where.append("query LIKE %s")
 		replacements.append("%" + query_filter + "%")
 
+	if not current_user.is_admin():
+		where.append("(is_private = FALSE OR owner = %s)")
+		replacements.append(current_user.get_id())
+
 	where = " AND ".join(where)
 
 	num_datasets = db.fetchone("SELECT COUNT(*) AS num FROM datasets WHERE " + where, tuple(replacements))["num"]
@@ -352,6 +362,9 @@ def show_results(page):
 	replacements.append(offset)
 	datasets = db.fetchall("SELECT key FROM datasets WHERE " + where + " ORDER BY timestamp DESC LIMIT %s OFFSET %s",
 						   tuple(replacements))
+
+	print("SELECT key FROM datasets WHERE " + where + " ORDER BY timestamp DESC LIMIT %s OFFSET %s")
+	print(replacements)
 
 	if not datasets and page != 1:
 		abort(404)
@@ -384,7 +397,10 @@ def show_result(key):
 	try:
 		dataset = DataSet(key=key, db=db)
 	except TypeError:
-		abort(404)
+		return error(404)
+		
+	if not current_user.can_access_dataset(dataset):
+		return error(403, error="This dataset is private.")
 
 	# child datasets are not available via a separate page - redirect to parent
 	if dataset.key_parent:
@@ -432,7 +448,10 @@ def preview_items(key):
 	try:
 		dataset = DataSet(key=key, db=db)
 	except TypeError:
-		return error(404, "Dataset not found.")
+		return error(404, error="Dataset not found.")
+		
+	if dataset.is_private and not (current_user.is_admin() or dataset.owner == current_user.get_id()):
+		return error(403, error="This dataset is private.")
 
 	preview_size = 1000
 
@@ -486,6 +505,34 @@ def toggle_favourite_interactive(key):
 		return render_template("error.html", message="Error while toggling favourite status for dataset %s." % key)
 
 
+@app.route("/result/<string:key>/toggle-private/")
+@login_required
+def toggle_private_interactive(key):
+	"""
+	Toggle dataset 'private' status
+
+	Uses code from corresponding API endpoint, but redirects to a normal page
+	rather than returning JSON as the API does, so this can be used for
+	'normal' links.
+
+	:param str key:  Dataset key
+	:return:
+	"""
+	success = toggle_private(key)
+	if not success.is_json:
+		return success
+
+	if success.json["success"]:
+		if success.json["is_private"]:
+			flash("Dataset has been made private")
+		else:
+			flash("Dataset has been made public")
+
+		return redirect("/results/" + key + "/")
+	else:
+		return render_template("error.html", message="Error while toggling private status for dataset %s." % key)
+
+
 @app.route("/result/<string:key>/restart/")
 @login_required
 def restart_dataset(key):
@@ -502,8 +549,11 @@ def restart_dataset(key):
 		dataset = DataSet(key=key, db=db)
 	except TypeError:
 		return error(404, message="Dataset not found.")
+		
+	if dataset.is_private and not (current_user.is_admin() or dataset.owner == current_user.get_id()):
+		return error(403, error="This dataset is private.")
 
-	if current_user.get_id() != dataset.parameters.get("user", "") and not current_user.is_admin:
+	if current_user.get_id() != dataset.owner and not current_user.is_admin():
 		return error(403, message="Not allowed.")
 
 	if not dataset.is_finished():
@@ -541,6 +591,9 @@ def nuke_dataset_interactive(key):
 		dataset = DataSet(key=key, db=db)
 	except TypeError:
 		return error(404, message="Dataset not found.")
+		
+	if not current_user.can_access_dataset(dataset):
+		return error(403, error="This dataset is private.")
 
 	top_key = dataset.top_parent().key
 	reason = request.form.get("reason", "")
@@ -572,6 +625,9 @@ def delete_dataset_interactive(key):
 		dataset = DataSet(key=key, db=db)
 	except TypeError:
 		return error(404, message="Dataset not found.")
+		
+	if not current_user.can_access_dataset(dataset):
+		return error(403, error="This dataset is private.")
 
 	top_key = dataset.top_parent().key
 


### PR DESCRIPTION
Can be toggled via the web interface. Private status determines who can view and manipulate datasets via the web interface. It does not encrypt data or anything like it.

Datasets are public by default, and can be set to private on the 'Create dataset' screen. Processors inherit the status of their parent.

* 'Create dataset' screen has 'make private' toggle, off by default. The tooltip for the option mentions that it will hide the dataset, but not encrypt it, and that instance maintainers can view it. It suggests to use a personal 4CAT instance instead for sensitive data.
* Each dataset has an 'owner', a user account that can view it if it is marked as private. Datasets with the owner 'anonymous' can be viewed by anyone.
* If dataset is private, it does not show up in the overview, and attempts to view its result page will result in an HTTP 403 error. Direct links to the result files still work for anyone that knows the link.
* Private results are marked with a lock icon in the overview and on the result page
* There is a 'make private' button on the result page (which toggles to 'make public') that the dataset owner and admins can use
* Processor datasets inherit the private/public status of their parent dataset
* Existing datasets remain public 