### PR TITLE
Save Telegram messages as NDJSON

### DIFF
--- a/datasources/telegram/DESCRIPTION.md
+++ b/datasources/telegram/DESCRIPTION.md
@@ -1,0 +1,33 @@
+The Telegram data source collects messages from channels or groups. You can optionally only collect messages within a 
+given date range, or only a given amount of messages per channel/group. Note that due to how Telegram works, you need 
+to know what channels or groups you want to collect data from before you collect it; you cannot search by keyword as 
+you can for some other platforms. 
+
+Telegram data is collected via Telegram's [official API](https://core.telegram.org/). This is done using the [Telethon 
+library](https://docs.telethon.dev/) for Python. Everything that happens in a channel or group within the parameters 
+is collected, though "actions" (such as someone joining or leaving a channel) are ignored. The resulting dataset then 
+comprises messages from users and their metadata. 
+
+### Data format
+Messages are saved as JSON objects, combined in one [NDJSON](http://ndjson.org/) file. For each message, the object 
+collected with Telethon is mapped to JSON. For each message, a lot of information is included, more than can be 
+explained here. The data is roughly congruent with [this 
+documentation](https://docs.telethon.dev/en/stable/modules/custom.html#telethon.tl.custom.message.Message). Most 
+metadata you may be interested in is included or can be derived from the included data.
+
+NDJSON files can also be downloaded as a CSV file in 4CAT. In this case, only the most important attributes
+of a message (such as message text, timestamp, author name, and whether it was forwarded) are included in the CSV file.
+
+### What can you do with the data?
+Telegram data lends itself well to text analysis, since for each message the full message text is captured. When 
+capturing messages from multiple groups, it can also be interesting to create a bipartite user-chat network, to see
+if particular users are present in multiple groups.
+
+4CAT can also download attached images and video thumbnails after creating a dataset, via the "Download Telegram 
+images" processor.
+
+### Further reading
+The following article offers some meditations on how to design data-driven Telegram research.
+
+* Peeters, S., & Willaert, T. (2022). Telegram and Digital Methods: Mapping Networked Conspiracy Theories through
+  Platform Affordances. <i>M/C Journal</i>, 25(1). [https://doi.org/10.5204/mcj.2878](https://doi.org/10.5204/mcj.2878)

--- a/datasources/telegram/DESCRIPTION.md
+++ b/datasources/telegram/DESCRIPTION.md
@@ -1,17 +1,20 @@
 The Telegram data source collects messages from channels or groups. You can optionally only collect messages within a 
-given date range, or only a given amount of messages per channel/group. Note that due to how Telegram works, you need 
-to know what channels or groups you want to collect data from before you collect it; you cannot search by keyword as 
-you can for some other platforms. 
+given date range, or only a given amount of messages per channel/group. 
 
-Telegram data is collected via Telegram's [official API](https://core.telegram.org/). This is done using the [Telethon 
+Note that due to how Telegram works, you need to know what channels or groups you want to collect data from before you 
+collect it; you cannot search by keyword as you can for some other platforms. You can, however, use the search function 
+in the Telegram app to find groups and channels, and then collect messages from the ones you find with 4CAT.
+
+Telegram data is collected via Telegram's [official API](https://core.telegram.org/) via the
+[MTProto](https://core.telegram.org/mtproto) protocol. This is done using the [Telethon 
 library](https://docs.telethon.dev/) for Python. Everything that happens in a channel or group within the parameters 
 is collected, though "actions" (such as someone joining or leaving a channel) are ignored. The resulting dataset then 
 comprises messages from users and their metadata. 
 
 ### Data format
 Messages are saved as JSON objects, combined in one [NDJSON](http://ndjson.org/) file. For each message, the object 
-collected with Telethon is mapped to JSON. For each message, a lot of information is included, more than can be 
-explained here. The data is roughly congruent with [this 
+collected with Telethon is mapped to JSON. A lot of information is included per message, more than can be explained 
+here. The data is roughly congruent with [this 
 documentation](https://docs.telethon.dev/en/stable/modules/custom.html#telethon.tl.custom.message.Message). Most 
 metadata you may be interested in is included or can be derived from the included data.
 

--- a/datasources/telegram/DESCRIPTION.md
+++ b/datasources/telegram/DESCRIPTION.md
@@ -5,11 +5,17 @@ Note that due to how Telegram works, you need to know what channels or groups yo
 collect it; you cannot search by keyword as you can for some other platforms. You can, however, use the search function 
 in the Telegram app to find groups and channels, and then collect messages from the ones you find with 4CAT.
 
+### Technical details and caveats
 Telegram data is collected via Telegram's [official API](https://core.telegram.org/) via the
 [MTProto](https://core.telegram.org/mtproto) protocol. This is done using the [Telethon 
 library](https://docs.telethon.dev/) for Python. Everything that happens in a channel or group within the parameters 
 is collected, though "actions" (such as someone joining or leaving a channel) are ignored. The resulting dataset then 
 comprises messages from users and their metadata. 
+
+If a message contains an attachment, the metadata of that attachment is recorded. This can then be used to download e.g.
+the attached image, but only if the 'Save session' option was checked when creating the dataset. If a message contains 
+multiple attachments, these are included and counted as separate messages (one of these will contain the actual message 
+text).
 
 ### Data format
 Messages are saved as JSON objects, combined in one [NDJSON](http://ndjson.org/) file. For each message, the object 

--- a/datasources/telegram/search_telegram.py
+++ b/datasources/telegram/search_telegram.py
@@ -76,7 +76,8 @@ class SearchTelegram(Search):
         },
         "query-intro": {
             "type": UserInput.OPTION_INFO,
-            "help": "You can scrape up to **25** entities (channels or groups) at a time. Separate with commas or line breaks."
+            "help": "You can collect messages from up to **25** entities (channels or groups) at a time. Separate with "
+                    "commas or line breaks."
         },
         "query": {
             "type": UserInput.OPTION_TEXT_LARGE,
@@ -584,6 +585,6 @@ class SearchTelegram(Search):
             if "max" in options["max_posts"]:
                 del options["max_posts"]["max"]
 
-            options["query-intro"]["help"] = "You can scrape any entities (channels or groups). Separate with commas or line breaks."
+            options["query-intro"]["help"] = "You can collect messages from multiple entities (channels or groups). Separate with commas or line breaks."
 
         return options

--- a/datasources/telegram/search_telegram.py
+++ b/datasources/telegram/search_telegram.py
@@ -395,7 +395,7 @@ class SearchTelegram(Search):
                 "dc_id": attachment["dc_id"],
                 "file_reference": attachment["file_reference"],
             })
-            attachment_filename = thread + "-" + message["id"] + ".jpeg"
+            attachment_filename = thread + "-" + str(message["id"]) + ".jpeg"
 
         elif attachment_type == "poll":
             # unfortunately poll results are only available when someone has

--- a/datasources/telegram/webtool/views.py
+++ b/datasources/telegram/webtool/views.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from telethon.sync import TelegramClient
 from telethon.errors.rpcerrorlist import FloodWaitError, ApiIdInvalidError, PhoneNumberInvalidError
 
+from datasources.telegram.search_telegram import SearchTelegram
+
 import config
 
 def authenticate(request, user, **kwargs):
@@ -38,8 +40,7 @@ def authenticate(request, user, **kwargs):
 	# Sessions are important because they are the way we don't need to enter
 	# the security code all the time. If we've tried logging in earlier use
 	# the same session again.
-	hash_base = kwargs["api_phone"] + kwargs["api_id"] + kwargs["api_hash"]
-	session_id = hashlib.blake2b(hash_base.encode("ascii")).hexdigest()
+	session_id = SearchTelegram.create_session_id(kwargs["api_phone"], kwargs["api_id"], kwargs["api_hash"])
 
 	# store session ID for user so it can be found again for later queries
 	user.set_value("telegram.session", session_id)

--- a/processors/visualisation/download-telegram-images.py
+++ b/processors/visualisation/download-telegram-images.py
@@ -127,10 +127,10 @@ class TelegramImageDownloader(BasicProcessor):
             if not message.get("attachment_data") or message.get("attachment_type") != "photo":
                 continue
 
-            if message["search_entity"] not in messages_with_photos:
-                messages_with_photos[message["search_entity"]] = []
+            if message["chat"] not in messages_with_photos:
+                messages_with_photos[message["chat"]] = []
 
-            messages_with_photos[message["search_entity"]].append(int(message["id"]))
+            messages_with_photos[message["chat"]].append(int(message["id"]))
             total_media += 1
 
             if amount and total_media >= amount:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ packages = [
 	"six==1.15.0",
 	"spacy==3.0.5",
 	"svgwrite==1.3.1",
-	"Telethon==1.10.6",
+	"Telethon==1.24.0",
 	"ural==0.30.0",
 	"Werkzeug==0.15.5",
 	"wordcloud==1.8.1",

--- a/webtool/static/css/stylesheet.css
+++ b/webtool/static/css/stylesheet.css
@@ -99,6 +99,10 @@ em, strong {
     font-weight: bold;
 }
 
+i {
+    font-style: italic;
+}
+
 table {
     margin: 1em auto;
     font-size: inherit;


### PR DESCRIPTION
Fixes #248.

Mapping the Telethon message object to JSON is a bit tricky. It works fine for channels and groups at the moment, but it needs some testing to make sure that it accounts for all types of messages that may be retrieved.

`map_item()` also needs testing for the various attachment types it may encounter.