### PR TITLE
Allow warn users

### DIFF
--- a/datasources/telegram/search_telegram.py
+++ b/datasources/telegram/search_telegram.py
@@ -290,6 +290,7 @@ class SearchTelegram(Search):
                     self.dataset.update_status(
                         "QUERY '%s' unable to complete due to error %s. Skipping." % (
                         query, str(e)))
+                    self.dataset.set_warn_user(True)
                     break
 
                 except TimeoutError:


### PR DESCRIPTION
Not sure if this is the best way to do this. I saw you had a `self.flawless` in mind. We still need something in the frontend. I thought that the last status message appeared, but apparently `[result-result-row.html](https://github.com/digitalmethodsinitiative/4cat/blob/ca99404978b8d2cbe31f151778b361f9ed14f489/webtool/templates/result-result-row.html#L1)` just checks to see if something `is_finished` and has some rows. If so "Completed!". When I saw that I felt less good about this approach, but the log is updated and I know the status is available with `dataset.get_status()`.