### PR TITLE
Update column filter to keep original dataset type

### DIFF
--- a/backend/abstract/processor.py
+++ b/backend/abstract/processor.py
@@ -697,7 +697,7 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 		return False
 
 	@classmethod
-	def get_extension(self):
+	def get_extension(self, dataset=None):
 		"""
 		Return the extension of the processor's dataset
 
@@ -705,10 +705,18 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 
 		:return str|None:  Dataset extension (without leading `.`) or `None`.
 		"""
-
-		if self.extension and not self.is_filter():
+		if self.is_filter():
+			if dataset is not None:
+				# Filters should use the same extension as the parent dataset
+				return dataset.get_parent().get_extension()
+			else:
+				# No dataset provided, unable to determine extension of parent dataset
+				return None
+		elif self.extension:
+			# Use explicitly defined extension in class (Processor class defaults to "csv")
 			return self.extension
-		return None
+		else:
+			return None
 
 	@classmethod
 	def is_rankable(cls, multiple_items=True):

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -47,7 +47,7 @@ class DataSet(FourcatModule):
 	no_status_updates = False
 	staging_area = None
 
-	def __init__(self, parameters={}, key=None, job=None, data=None, db=None, parent=None, extension="csv",
+	def __init__(self, parameters={}, key=None, job=None, data=None, db=None, parent=None, extension=None,
 				 type=None, is_private=True, owner="anonymous"):
 		"""
 		Create new dataset object
@@ -121,6 +121,11 @@ class DataSet(FourcatModule):
 			self.parameters = parameters
 
 			self.db.insert("datasets", data=self.data)
+			# Find desired extension from processor if not explicitly set
+			if extension is None:
+				extension = self.get_own_processor().get_extension(dataset=self)
+				if not extension:
+					extension = 'csv'
 			self.reserve_result_file(parameters, extension)
 
 		# retrieve analyses and processors that may be run for this dataset

--- a/processors/filtering/column_filter.py
+++ b/processors/filtering/column_filter.py
@@ -26,6 +26,7 @@ class ColumnFilter(BasicProcessor):
     title = "Filter by value"  # title displayed in UI
     description = "A generic filter that checks whether a value in a selected column matches a custom requirement. " \
                   "This will create a new dataset."
+    extension = None
 
     options = {
         "column": {},
@@ -97,15 +98,12 @@ class ColumnFilter(BasicProcessor):
         Reads a file, filtering items that match in the required way, and
         creates a new dataset containing the matching values
         """
-        # Set file extension to parent dataset type
-        self.extension = self.dataset.data['result_file'] = self.source_dataset.get_extension()
-
         # Filter posts
         matching_posts = self.filter_items()
 
         # Write the posts
         num_posts = 0
-        if self.extension == "csv":
+        if self.dataset.get_extension() == "csv":
             with self.dataset.get_results_path().open("w", encoding="utf-8") as outfile:
                 writer = None
                 for post in matching_posts:
@@ -114,7 +112,7 @@ class ColumnFilter(BasicProcessor):
                         writer.writeheader()
                     writer.writerow(post)
                     num_posts += 1
-        elif self.extension == "ndjson":
+        elif self..dataset.get_extension() == "ndjson":
             with self.dataset.get_results_path().open("w", encoding="utf-8", newline="") as outfile:
                 for post in matching_posts:
 

--- a/processors/filtering/column_filter.py
+++ b/processors/filtering/column_filter.py
@@ -64,6 +64,7 @@ class ColumnFilter(BasicProcessor):
         }
     }
 
+
     @classmethod
     def is_compatible_with(cls, module=None):
         """
@@ -97,7 +98,7 @@ class ColumnFilter(BasicProcessor):
         creates a new dataset containing the matching values
         """
         # Set file extension to parent dataset type
-        self.extension = self.source_dataset.get_extension()
+        self.extension = self.dataset.data['result_file'] = self.source_dataset.get_extension()
 
         # Filter posts
         matching_posts = self.filter_items()
@@ -116,6 +117,7 @@ class ColumnFilter(BasicProcessor):
         elif self.extension == "ndjson":
             with self.dataset.get_results_path().open("w", encoding="utf-8", newline="") as outfile:
                 for post in matching_posts:
+
                     outfile.write(json.dumps(post) + "\n")
                     num_posts += 1
         else:

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -860,11 +860,23 @@ def queue_processor(key=None, processor=None):
 	except QueryParametersException as e:
 		return error(400, error=str(e))
 
+	# Resolve extension
+	if available_processors[processor].extension is None:
+		parent_extension = dataset.get_extension()
+		if parent_extension is not None:
+			print('TESTING: grabbing parent extension %s' % str(parent_extension))
+			extension = parent_extension
+		else:
+			# This is a fallback since I don't know what would happen if I sent a None somewhere
+			extension = 'csv'
+	else:
+		extension = available_processors[processor].extension
+
 	# private or not is inherited from parent dataset
 	analysis = DataSet(parent=dataset.key,
 					   parameters=options,
 					   db=db,
-					   extension=available_processors[processor].extension,
+					   extension=extension,
 					   type=processor,
 					   is_private=dataset.is_private,
 					   owner=current_user.get_id()

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -860,23 +860,11 @@ def queue_processor(key=None, processor=None):
 	except QueryParametersException as e:
 		return error(400, error=str(e))
 
-	# Resolve extension
-	if available_processors[processor].extension is None:
-		parent_extension = dataset.get_extension()
-		if parent_extension is not None:
-			print('TESTING: grabbing parent extension %s' % str(parent_extension))
-			extension = parent_extension
-		else:
-			# This is a fallback since I don't know what would happen if I sent a None somewhere
-			extension = 'csv'
-	else:
-		extension = available_processors[processor].extension
-
 	# private or not is inherited from parent dataset
 	analysis = DataSet(parent=dataset.key,
 					   parameters=options,
 					   db=db,
-					   extension=extension,
+					   extension=available_processors[processor].get_extension(dataset=dataset),
 					   type=processor,
 					   is_private=dataset.is_private,
 					   owner=current_user.get_id()


### PR DESCRIPTION
This will keep a filtered dataset as the same type as the source dataset. There are some oddities that I'm not sure how to results. It seems the that the frontend doesn't know exactly what to do with it. I tried messing with the `extension`, but haven't found a good solution yet. If you filter an `ndjson` dataset, it doesn't seem to know the filtered dataset is an `ndjson` and defaults to csv. The preview is also wacky, likely it doesn't know to use the original `map_item` (and is presumably trying to read it as a csv file). 

I am a bit stumped as to how to create a processor with a variable extension. The extension is defined in the `__init__` of Dataset and when we are creating the processors (or search workers) we grab it from the processor/search Class. 

I tried some tricks to at least save the file as an `ndjson`, but other parts of the processor would fail (e.g. `Processor column-filter raised FileNotFoundError while processing dataset 82295e68c1babb62d8ce6c97fea55c76 (via  3e5a3ba3784e0bb1e0f78327ac17eb53) in column_filter.py:249->processor.py:586->dataset.py:441->shutil.py:418->shutil.py:264:                                                                                   [Errno 2] No such file or directory: '/usr/src/app/common/../data/column-filter-82295e68c1babb62d8ce6c97fea55c76.csv'`)

Fixes #253 