### PR TITLE
Send mail

### DIFF
--- a/common/lib/config_definition.py
+++ b/common/lib/config_definition.py
@@ -112,10 +112,11 @@ config_definition = {
         "tooltip": 'SMTP port to connect to for sending e-mail alerts. "0" defaults to "465" for SMTP_SSL or OS default for SMTP.',
     },
     "mail.ssl": {
-        "type": UserInput.OPTION_TOGGLE,
-        "default": False,
-        "help": "SMTP over SSL",
-        "tooltip": "Use SSL to connect to e-mail server?",
+        "type": UserInput.OPTION_CHOICE,
+        "default": "ssl",
+        "options": {"ssl": "SSL", "tls": "TLS", "none": "None"},
+        "help": "SMTP over SSL, TLS, or None",
+        "tooltip": "Security to use to connect to e-mail server",
     },
     "mail.username": {
         "type": UserInput.OPTION_TEXT,

--- a/common/lib/helpers.py
+++ b/common/lib/helpers.py
@@ -740,9 +740,9 @@ def send_email(recipient, message):
     context = ssl.create_default_context()
 
     # Decide which connection type
-    with smtplib.SMTP_SSL(config.get('mail.server'), port=config.get('mail.port', 0), context=context) if config.get('mail.ssl') else smtplib.SMTP(config.get('mail.server'), port=config.get('mail.port', 0)) as server:
-        if not config.get('mail.ssl'):
-            # smtplib.SMTP starts SSL here
+    with smtplib.SMTP_SSL(config.get('mail.server'), port=config.get('mail.port', 0), context=context) if config.get('mail.ssl') == 'ssl' else smtplib.SMTP(config.get('mail.server'), port=config.get('mail.port', 0)) as server:
+        if config.get('mail.ssl') == 'tls':
+            # smtplib.SMTP adds TLS context here
             server.starttls(context=context)
 
         # Log in

--- a/common/lib/helpers.py
+++ b/common/lib/helpers.py
@@ -2,6 +2,7 @@
 Miscellaneous helper functions for the 4CAT backend
 """
 import calendar
+import ssl
 import subprocess
 import requests
 import datetime
@@ -735,16 +736,26 @@ def send_email(recipient, message):
     :param list recipient:  Recipient e-mail addresses
     :param MIMEMultipart message:  Message to send
     """
-    connector = smtplib.SMTP_SSL if config.get('mail.ssl') else smtplib.SMTP
+    # Create a secure SSL context
+    context = ssl.create_default_context()
 
-    with connector(config.get('mail.server'), port=config.get('mail.port', 0)) as smtp:
+    # Decide which connection type
+    with smtplib.SMTP_SSL(config.get('mail.server'), port=config.get('mail.port', 0), context=context) if config.get('mail.ssl') else smtplib.SMTP(config.get('mail.server'), port=config.get('mail.port', 0)) as server:
+        if not config.get('mail.ssl'):
+            # smtplib.SMTP starts SSL here
+            server.starttls(context=context)
+
+        # Log in
         if config.get('mail.username') and config.get('mail.password'):
-            smtp.ehlo()
-            smtp.login(config.get('mail.username'), config.get('mail.password'))
+            server.ehlo()
+            server.login(config.get('mail.username'), config.get('mail.password'))
+
+        # Send message
         if type(message) == str:
-            smtp.sendmail(config.get('mail.noreply'), recipient, message)
+            server.sendmail(config.get('mail.noreply'), recipient, message)
         else:
-            smtp.sendmail(config.get('mail.noreply'), recipient, message.as_string())
+            server.sendmail(config.get('mail.noreply'), recipient, message.as_string())
+
 
 
 def flatten_dict(d: MutableMapping, parent_key: str = '', sep: str = '.'):


### PR DESCRIPTION
@stijn-uva, I believe this will fix this issue https://github.com/digitalmethodsinitiative/4cat/issues/299

It seems that they actually want TLS. I also found that, at least in some instances, mail servers will require different ports depending on which security. For example, it looks like Google requires 587 with TLS and 465 with SSL. Something to keep in mind if issues arise in the future.

As you know I cannot test this fix myself. I'll ask our guinea pig if they can try it out and update here.