### PR TITLE
fix root word not found in model bug

### DIFF
--- a/processors/text-analysis/similar_words.py
+++ b/processors/text-analysis/similar_words.py
@@ -25,6 +25,8 @@ class SimilarWord2VecWords(BasicProcessor):
 	description = "Uses a Word2Vec model to find words used in a similar context"  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
 
+	flawless = True
+
 	options = {
 		"words": {
 			"type": UserInput.OPTION_TEXT,
@@ -126,8 +128,9 @@ class SimilarWord2VecWords(BasicProcessor):
 						except KeyError:
 							if word not in excluded_words:
 								excluded_words.add(word)
-								self.dataset.log(f"'{word}' outside thresholds used for embedding model; no occurrences")
+								self.dataset.log(f"'{word}' outside thresholds used for embedding model {model_file.name}; no occurrences")
 							input_occurrences = 0
+							self.flawless = False
 
 						item_occurrences = model.get_vecattr(similar_word[0], "count")
 
@@ -159,4 +162,7 @@ class SimilarWord2VecWords(BasicProcessor):
 			self.dataset.update_status("None of the words were found in the word embedding model.", is_final=True)
 			self.dataset.finish(0)
 		else:
+			if not self.flawless:
+				self.dataset.update_status(
+					"Dataset complete, but some input words were not found in the embedding models (0 occurances in model due to chosen thresholds). Similar words are still identified; check log for specifics.", is_final=True)
 			self.write_csv_items_and_finish(result)

--- a/processors/text-analysis/similar_words.py
+++ b/processors/text-analysis/similar_words.py
@@ -115,17 +115,29 @@ class SimilarWord2VecWords(BasicProcessor):
 					except KeyError:
 						continue
 
+					# Some words may have been excluded from the embedding model due to thresholds
+					excluded_words = set()
 					for similar_word in similar_words:
 						if similar_word[1] < threshold:
 							continue
+
+						try:
+							input_occurrences = model.get_vecattr(word, "count")
+						except KeyError:
+							if word not in excluded_words:
+								excluded_words.add(word)
+								self.dataset.log(f"'{word}' outside thresholds used for embedding model; no occurrences")
+							input_occurrences = 0
+
+						item_occurrences = model.get_vecattr(similar_word[0], "count")
 
 						result.append({
 							"date": interval,
 							"input": word,
 							"item": similar_word[0],
 							"value": similar_word[1],
-							"input_occurences": model.get_vecattr(word, "count"),
-							"item_occurences": model.get_vecattr(similar_word[0], "count"),
+							"input_occurrences": input_occurrences,
+							"item_occurrences": item_occurrences,
 							"depth": level
 						})
 


### PR DESCRIPTION
This bug seems to appear when certain thresholds are used to create a word embedding model. Basically the keyword used to search for similar words is itself not in the embedding model. There are thus 0 occurrences of the word _in the model_. I created this pull request, because I'm not familiar with how these models are really being used and think that could cause confusion (as the word does exist in the corpus with some number of occurrences higher than 0!). The model is still able to find similar words with various probabilities so there is some "memory" of the word in the vectors. 

Interestingly, I just tested both the Word2Vec and the FastText models. The Word2Vec fails since the word is not in the embedding model, so this only occurs with the FastText model. I could thus disable the FastText model's ability to use the similar words not in the model, BUT the results appear meaningful. Compare these results:
[MAX_100_similar-word2vec-10f8f92b32fdf88492e8171e0b8c9745.csv](https://github.com/digitalmethodsinitiative/4cat/files/11212421/MAX_100_similar-word2vec-10f8f92b32fdf88492e8171e0b8c9745.csv)
[NO_MAX_similar-word2vec-b2a1cf8b4c213d7aadb60ca60c6b4560.csv](https://github.com/digitalmethodsinitiative/4cat/files/11212422/NO_MAX_similar-word2vec-b2a1cf8b4c213d7aadb60ca60c6b4560.csv)
Limiting to the top 100 words in the model and then seeing which of those words is most similar to a target word (in this case censorship), results in what appear to be more interesting words. There are likely other ways to get to this same sample (extract more words and filter by probability and and item_occurrences).

TLDR: Do I disable the FastText model running on input words not in the model's reduced corpus or do I allow the results as is even though the `input_occurrences` _could_ mislead a less critical user?