### PR TITLE
Telegram: Restore the user_id property when resolving users

### DIFF
--- a/datasources/telegram/search_telegram.py
+++ b/datasources/telegram/search_telegram.py
@@ -407,6 +407,7 @@ class SearchTelegram(Search):
                         self.details_cache[value["user_id"]] = SearchTelegram.serialize_obj(user)
 
                     resolved_message[key] = self.details_cache[value["user_id"]]
+                    resolved_message[key]["user_id"] = value["user_id"]
                 else:
                     resolved_message[key] = await self.resolve_groups(client, value)
 


### PR DESCRIPTION
`SearchTelegram.resolve_groups` takes the minimal ID information in `PeerUser` and `PeerChannel` objects within a Telegram message and expands them to their full user/channel objects respectively.  In the case of channels the method re-inserts the original `channel_id` property into the JSON, which is useful as it means that code that processes the output JSON but only cares about the channel ID can work unchanged whether it is given resolved or unresolved JSON as input.

However this is not currently done for users, so downstream code needs to be aware of this and pull the ID from either `user_id` or `full_user.id` as appropriate.

This PR extends the channel behaviour to users, re-inserting the original `user_id` property in its original place.