### PR TITLE
Email on completion of dataset option

### DIFF
--- a/.env
+++ b/.env
@@ -20,6 +20,7 @@ PUBLIC_PORT=80
 # Backend API
 # API_HOST is used by the frontend; in Docker it should be the backend container name
 # (or "localhost" if front and backend are running together in one container
+API_HOST=backend
 PUBLIC_API_PORT=4444
 
 # Telegram apparently needs its own port

--- a/.env
+++ b/.env
@@ -19,8 +19,7 @@ PUBLIC_PORT=80
 
 # Backend API
 # API_HOST is used by the frontend; in Docker it should be the backend container name
-# (or "localhost" if front and backend are running together in one container)
-API_HOST=backend
+# (or "localhost" if front and backend are running together in one container
 PUBLIC_API_PORT=4444
 
 # Telegram apparently needs its own port

--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -302,37 +302,37 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 		self.job.finish()
 
 		if config.get('mail.server') and self.dataset.get_parameters().get("email-complete", False):
-			for owner in self.dataset.get_owners_users():
-				# Check that username is email address
-				if re.match(r"[^@]+\@.*?\.[a-zA-Z]+", owner):
-					from email.mime.multipart import MIMEMultipart
-					from email.mime.text import MIMEText
-					from smtplib import SMTPException
-					import socket
-					import html2text
+			owner = self.dataset.get_parameters().get("email-complete", False)
+			# Check that username is email address
+			if re.match(r"[^@]+\@.*?\.[a-zA-Z]+", owner):
+				from email.mime.multipart import MIMEMultipart
+				from email.mime.text import MIMEText
+				from smtplib import SMTPException
+				import socket
+				import html2text
 
-					self.log.info("Sending email to %s" % owner)
-					dataset_url = ('https://' if config.get('flask.https') else 'http://') + config.get('flask.server_name') + '/results/' + self.dataset.key
-					sender = config.get('mail.noreply')
-					message = MIMEMultipart("alternative")
-					message["From"] = sender
-					message["To"] = owner
-					message["Subject"] = "4CAT dataset completed: %s" % self.dataset.get_label()
-					mail = """
-						<p>Hello %s,</p>
-						<p>4CAT has finished collecting your dataset labeled: %s</p>
-						<p>You can view your dataset via the following link:</p>
-						<p><a href="%s">%s</a></p> 
-						<p>Sincerely,</p>
-						<p>Your 4CAT admins</p>
-						""" % (owner, self.dataset.get_label(), dataset_url, dataset_url)
-					html_parser = html2text.HTML2Text()
-					message.attach(MIMEText(html_parser.handle(mail), "plain"))
-					message.attach(MIMEText(mail, "html"))
-					try:
-						send_email([owner], message)
-					except (SMTPException, ConnectionRefusedError, socket.timeout) as e:
-						self.log.error("Sending email to %s" % owner)
+				self.log.info("Sending email to %s" % owner)
+				dataset_url = ('https://' if config.get('flask.https') else 'http://') + config.get('flask.server_name') + '/results/' + self.dataset.key
+				sender = config.get('mail.noreply')
+				message = MIMEMultipart("alternative")
+				message["From"] = sender
+				message["To"] = owner
+				message["Subject"] = "4CAT dataset completed: %s" % self.dataset.get_label()
+				mail = """
+					<p>Hello %s,</p>
+					<p>4CAT has finished collecting your dataset labeled: %s</p>
+					<p>You can view your dataset via the following link:</p>
+					<p><a href="%s">%s</a></p> 
+					<p>Sincerely,</p>
+					<p>Your friendly neighborhood 4CAT admin</p>
+					""" % (owner, self.dataset.get_label(), dataset_url, dataset_url)
+				html_parser = html2text.HTML2Text()
+				message.attach(MIMEText(html_parser.handle(mail), "plain"))
+				message.attach(MIMEText(mail, "html"))
+				try:
+					send_email([owner], message)
+				except (SMTPException, ConnectionRefusedError, socket.timeout) as e:
+					self.log.error("Sending email to %s" % owner)
 
 
 	def remove_files(self):

--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -332,8 +332,7 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 				try:
 					send_email([owner], message)
 				except (SMTPException, ConnectionRefusedError, socket.timeout) as e:
-					self.log.error("Sending email to %s" % owner)
-
+					self.log.error("Error sending email to %s" % owner)
 
 	def remove_files(self):
 		"""

--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -311,21 +311,21 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 				import socket
 				import html2text
 
-				self.log.info("Sending email to %s" % owner)
+				self.log.debug("Sending email to %s" % owner)
 				dataset_url = ('https://' if config.get('flask.https') else 'http://') + config.get('flask.server_name') + '/results/' + self.dataset.key
 				sender = config.get('mail.noreply')
 				message = MIMEMultipart("alternative")
 				message["From"] = sender
 				message["To"] = owner
-				message["Subject"] = "4CAT dataset completed: %s" % self.dataset.get_label()
+				message["Subject"] = "4CAT dataset completed: %s - %s" % (self.dataset.type, self.dataset.get_label())
 				mail = """
 					<p>Hello %s,</p>
-					<p>4CAT has finished collecting your dataset labeled: %s</p>
+					<p>4CAT has finished collecting your %s dataset labeled: %s</p>
 					<p>You can view your dataset via the following link:</p>
 					<p><a href="%s">%s</a></p> 
 					<p>Sincerely,</p>
 					<p>Your friendly neighborhood 4CAT admin</p>
-					""" % (owner, self.dataset.get_label(), dataset_url, dataset_url)
+					""" % (owner, self.dataset.type, self.dataset.get_label(), dataset_url, dataset_url)
 				html_parser = html2text.HTML2Text()
 				message.attach(MIMEText(html_parser.handle(mail), "plain"))
 				message.attach(MIMEText(mail, "html"))

--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -575,7 +575,7 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 		self.dataset.update_status("Finished")
 		self.dataset.finish(len(data))
 
-	def write_archive_and_finish(self, files, num_items=None, compression=zipfile.ZIP_STORED, finish=True):
+	def write_archive_and_finish(self, files, num_items=None, compression=zipfile.ZIP_STORED):
 		"""
 		Archive a bunch of files into a zip archive and finish processing
 

--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -1,6 +1,7 @@
 """
 Basic post-processor worker - should be inherited by workers to post-process results
 """
+import re
 import traceback
 import zipfile
 import typing
@@ -300,10 +301,10 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 
 		self.job.finish()
 
-		if self.dataset.get_parameters().get("email-complete", False):
+		if config.get('mail.server') and self.dataset.get_parameters().get("email-complete", False):
 			for owner in self.dataset.get_owners_users():
-				# Absolute the minimum here
-				if "@" in owner:
+				# Check that username is email address
+				if re.match(r"[^@]+\@.*?\.[a-zA-Z]+", owner):
 					from email.mime.multipart import MIMEMultipart
 					from email.mime.text import MIMEText
 					from smtplib import SMTPException

--- a/common/lib/config_definition.py
+++ b/common/lib/config_definition.py
@@ -461,7 +461,13 @@ config_definition = {
         "default": True,
         "tooltip": "If a dataset is a JSON file but it can be mapped to a CSV file, show the CSV in the preview instead"
                    "of the underlying JSON."
-    }
+    },
+    "ui.option_email": {
+        "type": UserInput.OPTION_TOGGLE,
+        "help": "Show email when complete option",
+        "default": True,
+        "tooltip": "If a mail server is set up, enabling this allow users to request emails when datasets and processors are completed."
+    },
 }
 
 # These are used in the web interface for more readable names

--- a/common/lib/config_definition.py
+++ b/common/lib/config_definition.py
@@ -246,7 +246,7 @@ config_definition = {
     },
     "mail.server": {
         "type": UserInput.OPTION_TEXT,
-        "default": "localhost",
+        "default": "",
         "help": "SMTP server",
         "tooltip": "SMTP server to connect to for sending e-mail alerts.",
         "global": True

--- a/common/lib/config_definition.py
+++ b/common/lib/config_definition.py
@@ -463,9 +463,15 @@ config_definition = {
                    "of the underlying JSON."
     },
     "ui.option_email": {
-        "type": UserInput.OPTION_TOGGLE,
+        "type": UserInput.OPTION_CHOICE,
+        "options": {
+            "none": "No Emails",
+            "processor_only": "Processors only",
+            "datasources_only": "Create Dataset only",
+            "both": "Both datasets and processors"
+        },
+        "default": "none",
         "help": "Show email when complete option",
-        "default": True,
         "tooltip": "If a mail server is set up, enabling this allow users to request emails when datasets and processors are completed."
     },
 }

--- a/webtool/templates/components/processor-details.html
+++ b/webtool/templates/components/processor-details.html
@@ -61,10 +61,15 @@
                 {% for option in processor_options %}
                     {% include "components/processor-option.html" %}
                 {% endfor %}
-            {% if __user_config("mail.server") and '@' in current_user.get_name() %}
-                <div class="processor-option">
-                    <label for="email">Email address</label>
-                    <input type="email" name="email" id="email" value="{{ current_user.get_name() }}" placeholder="Email address">
+            {% if __user_config("mail.server") %}
+                <div class="form-element">
+                    <label for="data-email-complete">Receive email on completion:</label>
+                    <div class="filter-parameters">
+                        <label><input type="checkbox" name="email-complete" id="data-email-complete"></label>
+                        <label><input id="data-email-user" type="email" name="email-user" value={{ current_user.get_name() }}></label>
+                        <button class="tooltip-trigger" aria-controls="tooltip-dataset-email" aria-label="Extended help for option">?</button>
+                    </div>
+                    <p role="tooltip" id="tooltip-dataset-email">This will only function if your username is your email address.</p>
                 </div>
             {% endif %}
             </fieldset>

--- a/webtool/templates/components/processor-details.html
+++ b/webtool/templates/components/processor-details.html
@@ -61,7 +61,7 @@
                 {% for option in processor_options %}
                     {% include "components/processor-option.html" %}
                 {% endfor %}
-            {% if __user_config("ui.option_email") and __user_config("mail.server") %}
+            {% if __user_config("ui.option_email") in ["both", "processor_only"] and __user_config("mail.server") %}
                 <div class="form-element">
                     <label for="data-email-complete">Receive email on completion:</label>
                     <div class="filter-parameters">

--- a/webtool/templates/components/processor-details.html
+++ b/webtool/templates/components/processor-details.html
@@ -61,7 +61,7 @@
                 {% for option in processor_options %}
                     {% include "components/processor-option.html" %}
                 {% endfor %}
-            {% if __user_config("mail.server") %}
+            {% if __user_config("ui.option_email") and __user_config("mail.server") %}
                 <div class="form-element">
                     <label for="data-email-complete">Receive email on completion:</label>
                     <div class="filter-parameters">

--- a/webtool/templates/components/processor-details.html
+++ b/webtool/templates/components/processor-details.html
@@ -61,6 +61,12 @@
                 {% for option in processor_options %}
                     {% include "components/processor-option.html" %}
                 {% endfor %}
+            {% if __user_config("mail.server") and '@' in current_user.get_name() %}
+                <div class="processor-option">
+                    <label for="email">Email address</label>
+                    <input type="email" name="email" id="email" value="{{ current_user.get_name() }}" placeholder="Email address">
+                </div>
+            {% endif %}
             </fieldset>
         </div>
         {% endif %}

--- a/webtool/templates/components/result-metadata.html
+++ b/webtool/templates/components/result-metadata.html
@@ -26,7 +26,7 @@
     {% elif parameter == "country_name" and dataset.parameters[parameter] != "all" %}
         <span class="inline-label property-badge">country</span>
         <span class="inline-query">{{ dataset.parameters.country_name|join(', ') }}</span>
-    {% elif dataset.parameters[parameter] and parameter[0:4] != "api_" and parameter not in ("jst", "mst", "copied_from", "copied_at", "pseudonymise", "user", "time", "search-scope", "search_scope", "random_amount", "scope_length", "scope_density", "country_name", "min_date", "max_date", "board", "datasource", "type", "label", "expires-after") %}
+    {% elif dataset.parameters[parameter] and parameter[0:4] != "api_" and parameter not in ("jst", "mst", "copied_from", "copied_at", "pseudonymise", "user", "time", "search-scope", "search_scope", "random_amount", "scope_length", "scope_density", "country_name", "min_date", "max_date", "board", "datasource", "type", "label", "expires-after", "email-complete") %}
         {% if not dataset.parameters[parameter]|isbool and dataset.parameters[parameter] %}
         <span class="inline-label property-badge">{{ parameter }}</span>
         <span class="inline-query has-more" data-max-length="75">{{ dataset.parameters[parameter]|string }}</span>

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -60,7 +60,7 @@
 
                         <p role="tooltip" id="tooltip-dataset-private">This will only hide your dataset from other users. It will NOT encrypt your data and server administrators will still be able to view it. If you are working with sensitive data, you should consider running your own 4CAT instance.</p>
                     </div>
-                    {% if __user_config("ui.option_email") and __user_config("mail.server") %}
+                    {% if __user_config("ui.option_email") in ["both", "datasources_only"] and __user_config("mail.server") %}
                     <div class="form-element">
                         <label for="data-email-complete">Receive email on completion:</label>
                         <div class="filter-parameters">

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -61,6 +61,16 @@
                         <p role="tooltip" id="tooltip-dataset-private">This will only hide your dataset from other users. It will NOT encrypt your data and server administrators will still be able to view it. If you are working with sensitive data, you should consider running your own 4CAT instance.</p>
                     </div>
                     <div class="form-element">
+                        <label for="data-email-complete">Make private:</label>
+                        <div class="filter-parameters">
+                            <label><input type="checkbox" name="email-complete" id="data-email-complete" checked="checked"> Receive email when dataset is complete</label>
+                            <button class="tooltip-trigger" aria-controls="tooltip-dataset-email" aria-label="Extended help for option">?</button>
+                        </div>
+
+
+                        <p role="tooltip" id="tooltip-dataset-email">This will only function if your username is your email address.</p>
+                    </div>
+                    <div class="form-element">
                         <label for="dataset-label">Dataset name:</label>
                         <input id="dataset-label" name="label">
 

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -64,7 +64,7 @@
                     <div class="form-element">
                         <label for="data-email-complete">Receive email on completion:</label>
                         <div class="filter-parameters">
-                            <label><input type="checkbox" name="email-complete" id="data-email-complete" checked=""></label>
+                            <label><input type="checkbox" name="email-complete" id="data-email-complete"></label>
                             <label><input id="data-email-user" type="email" name="email-user" value={{ current_user.get_name() }}></label>
                             <button class="tooltip-trigger" aria-controls="tooltip-dataset-email" aria-label="Extended help for option">?</button>
                         </div>

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -60,15 +60,14 @@
 
                         <p role="tooltip" id="tooltip-dataset-private">This will only hide your dataset from other users. It will NOT encrypt your data and server administrators will still be able to view it. If you are working with sensitive data, you should consider running your own 4CAT instance.</p>
                     </div>
-                    {% if __user_config("mail.server") and '@' in current_user.get_name() %}
+                    {% if __user_config("mail.server") %}
                     <div class="form-element">
-                        <label for="data-email-complete">Make private:</label>
+                        <label for="data-email-complete">Receive email on completion:</label>
                         <div class="filter-parameters">
-                            <label><input type="checkbox" name="email-complete" id="data-email-complete" checked="checked"> Receive email when dataset is complete</label>
+                            <label><input type="checkbox" name="email-complete" id="data-email-complete" checked=""></label>
+                            <label><input id="data-email-user" type="email" name="email-user" value={{ current_user.get_name() }}></label>
                             <button class="tooltip-trigger" aria-controls="tooltip-dataset-email" aria-label="Extended help for option">?</button>
                         </div>
-
-
                         <p role="tooltip" id="tooltip-dataset-email">This will only function if your username is your email address.</p>
                     </div>
                     {% endif %}

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -60,7 +60,7 @@
 
                         <p role="tooltip" id="tooltip-dataset-private">This will only hide your dataset from other users. It will NOT encrypt your data and server administrators will still be able to view it. If you are working with sensitive data, you should consider running your own 4CAT instance.</p>
                     </div>
-                    {% if __user_config("mail.server") %}
+                    {% if __user_config("ui.option_email") and __user_config("mail.server") %}
                     <div class="form-element">
                         <label for="data-email-complete">Receive email on completion:</label>
                         <div class="filter-parameters">

--- a/webtool/templates/create-dataset.html
+++ b/webtool/templates/create-dataset.html
@@ -60,6 +60,7 @@
 
                         <p role="tooltip" id="tooltip-dataset-private">This will only hide your dataset from other users. It will NOT encrypt your data and server administrators will still be able to view it. If you are working with sensitive data, you should consider running your own 4CAT instance.</p>
                     </div>
+                    {% if __user_config("mail.server") and '@' in current_user.get_name() %}
                     <div class="form-element">
                         <label for="data-email-complete">Make private:</label>
                         <div class="filter-parameters">
@@ -70,6 +71,7 @@
 
                         <p role="tooltip" id="tooltip-dataset-email">This will only function if your username is your email address.</p>
                     </div>
+                    {% endif %}
                     <div class="form-element">
                         <label for="dataset-label">Dataset name:</label>
                         <input id="dataset-label" name="label">

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -1035,7 +1035,8 @@ def queue_processor(key=None, processor=None):
 	except QueryParametersException as e:
 		return error(400, error=str(e))
 
-	#TODO: add options['email-complete'] to options... based on something from request.form?
+	if request.form.to_dict().get("email-complete", False):
+		options["email-complete"] = request.form.to_dict().get("email-user", False)
 
 	# private or not is inherited from parent dataset
 	analysis = DataSet(parent=dataset.key,

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -333,7 +333,8 @@ def queue_dataset():
 	if request.form.to_dict().get("pseudonymise") in ("pseudonymise", "anonymise"):
 		sanitised_query["pseudonymise"] = request.form.to_dict().get("pseudonymise")
 
-	sanitised_query["email-complete"] = request.form.to_dict().get("email-complete", False)
+	if request.form.to_dict().get("email-complete", False):
+		sanitised_query["email-complete"] = request.form.to_dict().get("email-user", False)
 
 	# unchecked checkboxes do not send data in html forms, so key will not exist if box is left unchecked
 	is_private = bool(request.form.get("make-private", False))
@@ -1033,6 +1034,8 @@ def queue_processor(key=None, processor=None):
 		options = UserInput.parse_all(available_processors[processor].get_options(dataset, current_user), request.form, silently_correct=False)
 	except QueryParametersException as e:
 		return error(400, error=str(e))
+
+	#TODO: add options['email-complete'] to options... based on something from request.form?
 
 	# private or not is inherited from parent dataset
 	analysis = DataSet(parent=dataset.key,

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -333,6 +333,8 @@ def queue_dataset():
 	if request.form.to_dict().get("pseudonymise") in ("pseudonymise", "anonymise"):
 		sanitised_query["pseudonymise"] = request.form.to_dict().get("pseudonymise")
 
+	sanitised_query["email-complete"] = request.form.to_dict().get("email-complete", False)
+
 	# unchecked checkboxes do not send data in html forms, so key will not exist if box is left unchecked
 	is_private = bool(request.form.get("make-private", False))
 


### PR DESCRIPTION
This checks that a `mail.server` is set and adds an option to send an email on the completion of a dataset. Tested using a Gmail SMTP server and it works well.

Todo:
  - <s>hide new `email-complete` "query parameter" as it shows on the dataset as I used the same method as `is_private` and `pseudonymise`</s>.
 
For discussion: should we add this as an option for processors?
It could be useful for long running processors (download images/videos for example). But I am not sure we ought to add it as an individual option by processor as that seems repetitive and cumbersome to maintain. I am thinking perhaps a catch all at the top of a dataset page such as "Notify via email when processors are completed" that can easily be turned on and off. Then a User could choose for any dataset whether or not to be notified.