### PR TITLE
Use memcache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ packages = [
 	"psycopg2~=2.9.0",
 	"pyahocorasick~=1.4.0",
 	"PyMySQL~=1.0",
+	"python-memcached",
 	"PyTumblr==0.1.0",
 	"requests~=2.27",
 	"requests_futures",


### PR DESCRIPTION
The configuration manager currently queries the postgres database every time a config value is read. This is not a huge problem, since Postgres is fast and does some caching by itself. But it does mean a lot of database round-trips that are not necessary, because the value has not changed in the meantime and the query's result will not have changed either.

This PR optionally uses [memcached](https://en.wikipedia.org/wiki/Memcached) to cache these values so the database is only queried when necessary. If memcached is not available, the database is queried each time, same as before.