### PR TITLE
Allow dynamic form options in processors

### DIFF
--- a/common/lib/dmi_service_manager.py
+++ b/common/lib/dmi_service_manager.py
@@ -274,6 +274,7 @@ class DmiServiceManager:
             files_uploaded = 0
             while to_upload_filenames:
                 upload_file = to_upload_filenames.pop()
+                self.processor.dataset.log(f"Uploading {upload_file}")
                 # Upload files
                 if upload_file == empty_placeholder:
                     # Upload a blank results file to results folder

--- a/common/lib/user_input.py
+++ b/common/lib/user_input.py
@@ -5,6 +5,13 @@ import json
 
 import re
 
+class RequirementsNotMetException(Exception):
+    """
+    If this is raised while parsing, that option is not included in the parsed
+    output. Used with the "requires" option setting.
+    """
+    pass
+
 class UserInput:
     """
     Class for handling user input
@@ -70,6 +77,10 @@ class UserInput:
         # prefix
         input = {re.sub(r"^option-", "", field): input[field] for field in input}
 
+        # re-order input so that the fields relying on the value of other
+        # fields are parsed last
+        options = {k: options[k] for k in sorted(options, key=lambda k: options[k].get("requires") is not None)}
+
         for option, settings in options.items():
             if settings.get("indirect"):
                 # these are settings that are derived from and set by other
@@ -94,25 +105,31 @@ class UserInput:
                     option_max += "_proxy"
 
                 # save as a tuple of unix timestamps (or None)
-                after, before = (UserInput.parse_value(settings, input.get(option_min), silently_correct), UserInput.parse_value(settings, input.get(option_max), silently_correct))
+                try:
+                    after, before = (UserInput.parse_value(settings, input.get(option_min), parsed_input, silently_correct), UserInput.parse_value(settings, input.get(option_max), parsed_input, silently_correct))
 
-                if before and after and after > before:
-                    if not silently_correct:
-                        raise QueryParametersException("End of date range must be after beginning of date range.")
-                    else:
-                        before = after
+                    if before and after and after > before:
+                        if not silently_correct:
+                            raise QueryParametersException("End of date range must be after beginning of date range.")
+                        else:
+                            before = after
 
-                parsed_input[option] = (after, before)
+                    parsed_input[option] = (after, before)
+                except RequirementsNotMetException:
+                    pass
 
             elif settings.get("type") == UserInput.OPTION_TOGGLE:
                 # special case too, since if a checkbox is unchecked, it simply
                 # does not show up in the input
-                if option in input:
-                    # Toggle needs to be parsed
-                    parsed_input[option] = UserInput.parse_value(settings, input[option], silently_correct)
-                else:
-                    # Toggle was left blank
-                    parsed_input[option] = False
+                try:
+                    if option in input:
+                        # Toggle needs to be parsed
+                        parsed_input[option] = UserInput.parse_value(settings, input[option], parsed_input, silently_correct)
+                    else:
+                        # Toggle was left blank
+                        parsed_input[option] = False
+                except RequirementsNotMetException:
+                    pass
 
             elif settings.get("type") == UserInput.OPTION_DATASOURCES:
                 # special case, because this combines multiple inputs to
@@ -132,12 +149,15 @@ class UserInput:
 
             else:
                 # normal parsing and sanitisation
-                parsed_input[option] = UserInput.parse_value(settings, input[option], silently_correct)
+                try:
+                    parsed_input[option] = UserInput.parse_value(settings, input[option], parsed_input, silently_correct)
+                except RequirementsNotMetException:
+                    pass
 
         return parsed_input
 
     @staticmethod
-    def parse_value(settings, choice, silently_correct=True):
+    def parse_value(settings, choice, other_input=None, silently_correct=True):
         """
         Filter user input
 
@@ -146,12 +166,46 @@ class UserInput:
 
         :param obj settings:  Settings, including defaults and valid options
         :param choice:  The chosen option, to be parsed
+        :param dict other_input:  Other input, as parsed so far
         :param bool silently_correct:  If true, replace invalid values with the
         given default value; else, raise a QueryParametersException if a value
         is invalid.
 
         :return:  Validated and parsed input
         """
+        # short-circuit if there is a requirement for the field to be parsed
+        # and the requirement isn't met
+        if settings.get("requires"):
+            try:
+                field, operator, value = re.findall(r"([a-zA-Z0-9_]+)([!=$~^]+)(.*)", settings.get("requires"))[0]
+            except IndexError:
+                # invalid condition, interpret as 'does the field with this name have a value'
+                field, operator, value = (choice, "!=", "")
+
+            if field not in other_input:
+                raise RequirementsNotMetException()
+
+            other_value = other_input.get(field)
+            if type(other_value) is bool:
+                # evalues to a boolean, i.e. checkboxes etc
+                if operator == "!=":
+                    if (other_value and value in ("", "false")) or (not other_value and value in ("true", "checked")):
+                        raise RequirementsNotMetException()
+                else:
+                    if (other_value and value not in ("true", "checked")) or (not other_value and value not in ("", "false")):
+                        raise RequirementsNotMetException()
+
+            elif operator == "^=" and not str(other_input.get(field)).startswith(value):
+                raise RequirementsNotMetException()
+            elif operator == "$=" and not str(other_input.get(field)).endswith(value):
+                raise RequirementsNotMetException()
+            elif operator == "~=" and value not in str(other_input.get(field)):
+                raise RequirementsNotMetException()
+            elif operator == "!=" and value == other_input.get(field):
+                raise RequirementsNotMetException()
+            elif operator in ("==", "=") and value != other_input.get(field):
+                raise RequirementsNotMetException()
+
         input_type = settings.get("type", "")
         if input_type in UserInput.OPTIONS_COSMETIC:
             # these are structural form elements and can never return a value

--- a/common/lib/user_input.py
+++ b/common/lib/user_input.py
@@ -279,7 +279,7 @@ class UserInput:
             # return option if valid, or default
             if choice not in settings.get("options"):
                 if not silently_correct:
-                    raise QueryParametersException("Invalid value selected; must be one of %s." % ", ".join(settings.get("options", {}).keys()))
+                    raise QueryParametersException(f"Invalid value selected; must be one of {', '.join(settings.get('options', {}).keys())}. {settings}")
                 else:
                     return settings.get("default", "")
             else:

--- a/common/lib/user_input.py
+++ b/common/lib/user_input.py
@@ -195,16 +195,29 @@ class UserInput:
                     if (other_value and value not in ("true", "checked")) or (not other_value and value not in ("", "false")):
                         raise RequirementsNotMetException()
 
-            elif operator == "^=" and not str(other_input.get(field)).startswith(value):
-                raise RequirementsNotMetException()
-            elif operator == "$=" and not str(other_input.get(field)).endswith(value):
-                raise RequirementsNotMetException()
-            elif operator == "~=" and value not in str(other_input.get(field)):
-                raise RequirementsNotMetException()
-            elif operator == "!=" and value == other_input.get(field):
-                raise RequirementsNotMetException()
-            elif operator in ("==", "=") and value != other_input.get(field):
-                raise RequirementsNotMetException()
+            else:
+                if type(other_value) in (tuple, list):
+                # iterables are a bit special
+                    if len(other_value) == 1:
+                        # treat one-item lists as "normal" values
+                        other_value = other_value[0]
+                    elif operator == "~=":  # interpret as 'is in list?'
+                        if value not in other_value:
+                            raise RequirementsNotMetException()
+                    else:
+                        # condition doesn't make sense for a list, so assume it's not True
+                        raise RequirementsNotMetException()
+
+                if operator == "^=" and not str(other_value).startswith(value):
+                    raise RequirementsNotMetException()
+                elif operator == "$=" and not str(other_value).endswith(value):
+                    raise RequirementsNotMetException()
+                elif operator == "~=" and value not in str(other_value):
+                    raise RequirementsNotMetException()
+                elif operator == "!=" and value == other_value:
+                    raise RequirementsNotMetException()
+                elif operator in ("==", "=") and value != other_value:
+                    raise RequirementsNotMetException()
 
         input_type = settings.get("type", "")
         if input_type in UserInput.OPTIONS_COSMETIC:

--- a/processors/text-analysis/tokenise.py
+++ b/processors/text-analysis/tokenise.py
@@ -115,14 +115,16 @@ class Tokenise(BasicProcessor):
 				"type": UserInput.OPTION_TOGGLE,
 				"default": False,
 				"help": "Stem tokens (with SnowballStemmer)",
-				"tooltip": "Stemming removes suffixes from words: 'running' becomes 'runn', 'bicycles' becomes 'bicycl', etc."
+				"tooltip": "Stemming removes suffixes from words: 'running' becomes 'runn', 'bicycles' becomes 'bicycl', etc.",
+				"requires": "language!=other"
 			},
 			"lemmatise": {
 				"type": UserInput.OPTION_TOGGLE,
 				"default": False,
 				"help": "Lemmatise tokens (English only)",
 				"tooltip": "Lemmatisation replaces variations of a word with its root form: 'running' becomes 'run', 'bicycles' " \
-						   " becomes 'bicycle', 'better' becomes 'good'."
+						   " becomes 'bicycle', 'better' becomes 'good'.",
+				"requires": "language==english"
 			},
 			"accept_words": {
 				"type": UserInput.OPTION_TEXT,

--- a/webtool/static/js/fourcat.js
+++ b/webtool/static/js/fourcat.js
@@ -1837,7 +1837,7 @@ const ui_helpers = {
                             requirement_met = true;
                         }
                     } else {
-                        if((checked && ['checked', 'true'].includes(requirement)) || (!checked) && ['', 'false'].includes(requirement[3])) {
+                        if((checked && ['checked', 'true'].includes(requirement[3])) || (!checked && ['', 'false'].includes(requirement[3]))) {
                             requirement_met = true;
                         }
                     }
@@ -1926,7 +1926,7 @@ function FileReaderPromise(file) {
         fr.onload = () => {
             resolve(fr.result);
         }
-        fr.readAsArrayBuffer(file);
+        fr.readAsText(file);
     });
 }
 

--- a/webtool/static/js/fourcat.js
+++ b/webtool/static/js/fourcat.js
@@ -737,6 +737,8 @@ const query = {
                     multichoice.makeMultichoice();
                     multichoice.makeMultiSelect();
                 }
+
+                ui_helpers.conditional_form.manage(document.getElementById('query-form'));
             },
             'error': function () {
                 $('#datasource-select').parents('form').trigger('reset');
@@ -1451,7 +1453,7 @@ const ui_helpers = {
         $(document).on('input', '.copy-from', ui_helpers.table_control);
 
         //mighty morphing web forms
-        $(document).on('input', 'form.processor-child-wrapper input, form.processor-child-wrapper select', ui_helpers.conditional_form.manage);
+        $(document).on('input', 'form.processor-child-wrapper input, form.processor-child-wrapper select, #query-form input, #query-form select', ui_helpers.conditional_form.manage);
         ui_helpers.conditional_form.init();
 
         //iframe flexible sizing
@@ -1767,7 +1769,7 @@ const ui_helpers = {
         /**
          * Set visibility of form elements when they are loaded
          */
-        init: function() {
+        init: function(form=null) {
             document.querySelectorAll('*[data-requires]').forEach((element) => {
                 const form = $(element).parents('form')[0];
                 if(form.getAttribute('data-form-managed')) {
@@ -1780,10 +1782,17 @@ const ui_helpers = {
         /**
          * Manage visibility of form elements when forms are interacted with
 
-         * @param e  Event
+         * @param e  Event, or a form object
          */
         manage: function (e) {
-            const form = $(e.target).parents('form')[0];
+            let form;
+
+            if('tagName' in e && e.tagName === 'FORM') {
+                form = e;
+            } else {
+                form = $(e.target).parents('form')[0];
+            }
+
             form.setAttribute('data-form-managed', true);
             const conditionals = form.querySelectorAll('*[data-requires]');
 
@@ -1806,6 +1815,7 @@ const ui_helpers = {
                 }
 
                 const other_value = other_element.value;
+
                 let requirement_met = false;
                 if (other_element.getAttribute('type') === 'checkbox') {
                     // checkboxes are a bit different (and simpler)

--- a/webtool/static/js/fourcat.js
+++ b/webtool/static/js/fourcat.js
@@ -1693,7 +1693,9 @@ const ui_helpers = {
             e.preventDefault();
         }
 
-        let target = '#' + $(e.target).attr('aria-controls');
+        const button_target = $(e.target).is('.toggle-button, .processor-queue-button') ? $(e.target) : $(e.target).parents('.toggle-button, .processor-queue-button')[0];
+
+        let target = '#' + $(button_target).attr('aria-controls');
         let is_open = $(target).attr('aria-expanded') !== 'false';
 
         if (is_open || force_close) {

--- a/webtool/templates/components/datasource-option.html
+++ b/webtool/templates/components/datasource-option.html
@@ -11,7 +11,7 @@
             <input name="option-{{ option }}" id="forminput-{{ option }}" type="checkbox" {% if settings.default %} checked{% endif %}>
             {% if "tooltip" in settings %}<p class="option-help">{{ settings.tooltip }}</p>{% endif %}
         {% elif settings.type == "file" %}
-            <input name="option-{{ option }}" id="forminput-{{ option }}" type="file"{% if option_settings.accept %}accept=".csv"{% endif %}>
+            <input name="option-{{ option }}" id="forminput-{{ option }}" type="file"{% if settings.accept %}accept=".csv"{% endif %}>
             {% if "tooltip" in settings %}
                 <button class="tooltip-trigger" aria-controls="tooltip-option-{{ option }}" aria-label="Extended help for option">?</button>
     	        <p role="tooltip" id="tooltip-option-{{ option }}">

--- a/webtool/templates/components/datasource-option.html
+++ b/webtool/templates/components/datasource-option.html
@@ -2,9 +2,9 @@
         </fieldset>
         {% set fieldset.open = False %}
     {% elif settings.type == "info" %}
-        <p class="form-intro">{{ settings.help|markdown|safe }}</p>
+        <p class="form-intro"{% if settings.requires %} data-requires="{{ settings.requires }}"{% endif %}>{{ settings.help|markdown|safe }}</p>
     {% else %}
-        <div class="form-element{% if settings.cache %} cacheable{% endif %}"{% if settings.board_specific %} data-board-specific="{{ settings.board_specific|join('-') }}"{% endif %}>
+        <div class="form-element{% if settings.cache %} cacheable{% endif %}"{% if settings.board_specific %} data-board-specific="{{ settings.board_specific|join('-') }}"{% endif %}{% if settings.requires %} data-requires="{{ settings.requires }}"{% endif %}>
             <label for="forminput-{{ option }}">{{ settings.help }}</label>
             <div{% if settings.type == "toggle" %} class="with-tail"{% endif %}>
         {% if settings.type == "toggle" %}

--- a/webtool/templates/components/datasource-option.html
+++ b/webtool/templates/components/datasource-option.html
@@ -11,7 +11,7 @@
             <input name="option-{{ option }}" id="forminput-{{ option }}" type="checkbox" {% if settings.default %} checked{% endif %}>
             {% if "tooltip" in settings %}<p class="option-help">{{ settings.tooltip }}</p>{% endif %}
         {% elif settings.type == "file" %}
-            <input name="option-{{ option }}" id="forminput-{{ option }}" type="file">
+            <input name="option-{{ option }}" id="forminput-{{ option }}" type="file"{% if option_settings.accept %}accept=".csv"{% endif %}>
             {% if "tooltip" in settings %}
                 <button class="tooltip-trigger" aria-controls="tooltip-option-{{ option }}" aria-label="Extended help for option">?</button>
     	        <p role="tooltip" id="tooltip-option-{{ option }}">

--- a/webtool/templates/components/processor-details.html
+++ b/webtool/templates/components/processor-details.html
@@ -4,7 +4,7 @@
     {# The button for this processor #}
     {% set processor_options = processor.get_options(dataset, current_user) %}
     <div class="button-wrap processor-result-indicator">
-        <button class="processor-queue-button{% if processor_options %} toggle-button{% endif %} {{processor.type}}-button" {% if processor_options %}aria-controls="processor-options-{{ dataset.key }}-{{ processor.type }}"{% endif %}>
+        <button class="processor-queue-button {{processor.type}}-button" {% if processor_options %}aria-controls="processor-options-{{ dataset.key }}-{{ processor.type }}"{% endif %}>
             <span class="headline">
                 <i class="fa fa-{% if processor_options %}cog{% else %}play{% endif %}" aria-hidden="true"></i>
             </span>

--- a/webtool/templates/components/processor-option.html
+++ b/webtool/templates/components/processor-option.html
@@ -36,6 +36,8 @@
             {% endfor %}
             </select>
         </div>
+    {% elif option_settings.type == "file" %}
+        <input name="option-{{ option }}" value="{{ option_settings.default }}" type="file"{% if option_settings.accept %}accept=".csv"{% endif %}>
     {% elif option_settings.type == "daterange" %}
         <div class="daterange-wrapper">
             <input name="option-{{ option }}-min_proxy" id="forminput-{{ option }}" class="input-time" type="date"

--- a/webtool/templates/components/processor-option.html
+++ b/webtool/templates/components/processor-option.html
@@ -1,5 +1,5 @@
 {% set option_settings = processor.get_options(dataset, current_user)[option] %}
-<div class="processor-option-wrap">
+<div class="processor-option-wrap"{% if option_settings.requires %} data-requires="{{ option_settings.requires }}"{% endif %}>
     <label class="option-type-{{ option_settings.type }}">
         {% if option_settings.type == "toggle" %}
             <input type="checkbox" name="option-{{ option }}"{% if option_settings.default %} checked="checked"{% endif %}>


### PR DESCRIPTION
This PR adds a setting to processor options, `requires`, which controls the visibility of the option. For example, this could be used to only make a field asking for an API key appear if a processor option that necessitates the use of that API is chosen:

```python3
options = {
  "model": {
    "type": UserInput.OPTION_CHOICE,
    "help": "LLM to use for analysis",
    "options": {
        "openai": "Use OpenAI LLM",
        "local": "Use LLM running on local GPU"
    }
  },
  "apikey": {
    "type": UserInput.OPTION_TEXT,
    "help": "OpenAI API key",
    "requires": "model=openai"
  }
}
```

In this example, the 'apikey' control would only be available if 'Use OpenAI LLM' is chosen in the first option.

There is a limited set of other syntaxes to use for the `requires` setting:

* `"requires": "model"`: Enable if `model` is not empty, or (in the case of a boolean/checkbox) not `False`. Equivalent to `"requires": "model!="`.
* `"requires": "model=openai"`: Enable if `model` is `openai`.
* `"requires": "model!=openai"`: Enable if `model` is not `openai`.
* `"requires": "model~=openai"`: Enable if `model` contains `openai`.
* `"requires": "model^=openai"`: Enable if `model` starts with `openai`.
* `"requires": "model$=openai"`: Enable if `model` ends with `openai`.

If the `requires` condition is not met, the processor behaves as if the option does not exist at all, i.e. no value is stored for it.

Behaviour for options whose `requires` condition involves the value of other options with a `requires` setting is undefined (i.e. you shouldn't do that).