### PR TITLE
fix is_4cat_class

### DIFF
--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -836,4 +836,16 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 		"""
 		pass
 
+	@staticmethod
+	def is_4cat_processor():
+		"""
+		Is this a 4CAT processor?
+
+		This is used to determine whether a class is a 4CAT
+		processor.
+		
+		:return:  True
+		"""
+		return True
+
 

--- a/backend/lib/worker.py
+++ b/backend/lib/worker.py
@@ -167,3 +167,27 @@ class BasicWorker(threading.Thread, metaclass=abc.ABCMeta):
 		classes should implement this method.
 		"""
 		pass
+
+	@staticmethod
+	def is_4cat_class():
+		"""
+		Is this a 4CAT class?
+
+		This is used to determine whether a class is a 4CAT worker or a
+		processor. This method should always return True for workers.
+
+		:return:  True
+		"""
+		return True
+	
+	@staticmethod
+	def is_4cat_processor():
+		"""
+		Is this a 4CAT processor?
+
+		This is used to determine whether a class is a 4CAT
+		processor.
+		
+		:return:  False
+		"""
+		return False

--- a/common/lib/module_loader.py
+++ b/common/lib/module_loader.py
@@ -69,23 +69,21 @@ class ModuleCollector:
         """
         Determine if a module member is a worker class we can use
         """
-        # it would be super cool to just use issubclass() here!
-        # but that requires importing the classes themselves, which leads to
-        # circular imports
-        # todo: fix this because this sucks
-        # agreed - Dale
-        parent_classes = {"BasicWorker", "BasicProcessor", "Search", "SearchWithScope", "Search4Chan",
-                          "ProcessorPreset", "TwitterStatsBase", "BaseFilter", "TwitterAggregatedStats", "ColumnFilter",
-                          "BasicJSONScraper", "BoardScraper4chan", "ThreadScraper4chan"}
-        if only_processors:
-            # only allow processors
-            for worker_only_class in ["BasicWorker", "BasicJSONScraper", "BoardScraper4chan", "ThreadScraper4chan"]:
-                parent_classes.remove(worker_only_class)
-
-        return inspect.isclass(object) and \
-               parent_classes & set([f.__name__ for f in object.__bases__]) and \
-               object.__name__ not in("BasicProcessor", "BasicWorker") and \
-               not inspect.isabstract(object)
+        if inspect.isclass(object):
+            if object.__name__ in("BasicProcessor", "BasicWorker") or inspect.isabstract(object):
+                # ignore abstract and base classes
+                return False
+                
+            if hasattr(object, "is_4cat_class"):
+                if only_processors:
+                    if hasattr(object, "is_4cat_processor"):
+                        return object.is_4cat_processor()
+                    else:
+                        return False
+                else:
+                    return object.is_4cat_class()
+        
+        return False
 
     def load_modules(self):
         """


### PR DESCRIPTION
I created some staticmethods in BasicWorker and BasicProcessor that the ModuleCollector can use to check for 4CAT classes. It may even be useful elsewhere, but this fixes the need to add subclasses to the `is_4cat_class` method of the ModuleCollector when creating new ones (presuming that they are still descendants of BasicWorker and BasicProcessor).