### PR TITLE
Add method to processors to toggle display in UI

### DIFF
--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -82,6 +82,9 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 	#: Is this processor running 'within' a preset processor?
 	is_running_in_preset = False
 
+	#: Is this processor hidden in the front-end, and only used internally/in presets?
+	is_hidden = False
+
 	#: This will be defined automatically upon loading the processor. There is
 	#: no need to override manually
 	filepath = None
@@ -237,7 +240,7 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 			next_parameters = next.get("parameters", {})
 			next_type = next.get("type", "")
 			try:
-				available_processors = self.dataset.get_available_processors(user=self.dataset.creator, ui_only=False)
+				available_processors = self.dataset.get_available_processors(user=self.dataset.creator)
 			except ValueError:
 				self.log.info("Trying to queue next processor, but parent dataset no longer exists, halting")
 				break
@@ -808,16 +811,6 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 		:return bool:  Always `False`, because this is a processor.
 		"""
 		return False
-
-	@classmethod
-	def display_in_ui(cls):
-		"""
-        Display this processor in the 4CAT web interface True/False. This is used to hide processors that are not
-        intended to be used by the user, but are instead used as part of a preset or other processor.
-
-        :return bool:  True if this processor should be displayed in the 4CAT web interface, False otherwise
-        """
-		return True
 
 	@classmethod
 	def is_from_collector(cls):

--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -237,7 +237,7 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 			next_parameters = next.get("parameters", {})
 			next_type = next.get("type", "")
 			try:
-				available_processors = self.dataset.get_available_processors(user=self.dataset.creator)
+				available_processors = self.dataset.get_available_processors(user=self.dataset.creator, ui_only=False)
 			except ValueError:
 				self.log.info("Trying to queue next processor, but parent dataset no longer exists, halting")
 				break
@@ -808,6 +808,16 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
 		:return bool:  Always `False`, because this is a processor.
 		"""
 		return False
+
+	@classmethod
+	def display_in_ui(cls):
+		"""
+        Display this processor in the 4CAT web interface True/False. This is used to hide processors that are not
+        intended to be used by the user, but are instead used as part of a preset or other processor.
+
+        :return bool:  True if this processor should be displayed in the 4CAT web interface, False otherwise
+        """
+		return True
 
 	@classmethod
 	def is_from_collector(cls):

--- a/backend/lib/search.py
+++ b/backend/lib/search.py
@@ -94,7 +94,7 @@ class Search(BasicProcessor, ABC):
 			for next in query_parameters.get("next"):
 				next_parameters = next.get("parameters", {})
 				next_type = next.get("type", "")
-				available_processors = self.dataset.get_available_processors(user=self.dataset.creator, ui_only=False)
+				available_processors = self.dataset.get_available_processors(user=self.dataset.creator)
 
 				# run it only if the processor is actually available for this query
 				if next_type in available_processors:

--- a/backend/lib/search.py
+++ b/backend/lib/search.py
@@ -94,7 +94,7 @@ class Search(BasicProcessor, ABC):
 			for next in query_parameters.get("next"):
 				next_parameters = next.get("parameters", {})
 				next_type = next.get("type", "")
-				available_processors = self.dataset.get_available_processors(user=self.dataset.creator)
+				available_processors = self.dataset.get_available_processors(user=self.dataset.creator, ui_only=False)
 
 				# run it only if the processor is actually available for this query
 				if next_type in available_processors:

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -1390,7 +1390,7 @@ class DataSet(FourcatModule):
 		processor_type = self.parameters.get("type", self.data.get("type"))
 		return backend.all_modules.processors.get(processor_type)
 
-	def get_available_processors(self, user=None, ui_only=True):
+	def get_available_processors(self, user=None, exclude_hidden=False):
 		"""
 		Get list of processors that may be run for this dataset
 
@@ -1401,15 +1401,15 @@ class DataSet(FourcatModule):
 
 		:param str|User|None user:  User to get compatibility for. If set,
 		use the user-specific config settings where available.
-		:param bool ui_only:  Only return processors that should be displayed
-		in the UI. If `False`, all processors are returned.
+		:param bool exclude_hidden:  Return processors that should be displayed
+		in the UI? If `False`, all processors are returned.
 
 		:return dict:  Available processors, `name => properties` mapping
 		"""
 		if self.available_processors:
-			# Update to reflect ui_only parameter which may be different from last call
+			# Update to reflect exclude_hidden parameter which may be different from last call
 			# TODO: could children also have been created? Possible bug, but I have not seen anything effected by this
-			return {processor_type: processor for processor_type, processor in self.available_processors.items() if not ui_only or processor.display_in_ui()}
+			return {processor_type: processor for processor_type, processor in self.available_processors.items() if not exclude_hidden or processor.is_hidden}
 
 		processors = self.get_compatible_processors(user=user)
 
@@ -1421,7 +1421,7 @@ class DataSet(FourcatModule):
 				del processors[analysis.type]
 				continue
 
-			if ui_only and not processors[analysis.type].display_in_ui():
+			if exclude_hidden and not processors[analysis.type].is_hidden:
 				del processors[analysis.type]
 
 		self.available_processors = processors

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -1409,7 +1409,7 @@ class DataSet(FourcatModule):
 		if self.available_processors:
 			# Update to reflect ui_only parameter which may be different from last call
 			# TODO: could children also have been created? Possible bug, but I have not seen anything effected by this
-			return [self.available_processors for processor in self.available_processors if not ui_only or processor.display_in_ui()]
+			return {processor_type: processor for processor_type, processor in self.available_processors.items() if not ui_only or processor.display_in_ui()}
 
 		processors = self.get_compatible_processors(user=user)
 

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -1401,7 +1401,7 @@ class DataSet(FourcatModule):
 
 		:param str|User|None user:  User to get compatibility for. If set,
 		use the user-specific config settings where available.
-		:param bool exclude_hidden:  Return processors that should be displayed
+		:param bool exclude_hidden:  Exclude processors that should be displayed
 		in the UI? If `False`, all processors are returned.
 
 		:return dict:  Available processors, `name => properties` mapping

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -1419,6 +1419,7 @@ class DataSet(FourcatModule):
 
 			if not processors[analysis.type].get_options():
 				del processors[analysis.type]
+				continue
 
 			if ui_only and not processors[analysis.type].display_in_ui():
 				del processors[analysis.type]

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -1409,7 +1409,7 @@ class DataSet(FourcatModule):
 		if self.available_processors:
 			# Update to reflect exclude_hidden parameter which may be different from last call
 			# TODO: could children also have been created? Possible bug, but I have not seen anything effected by this
-			return {processor_type: processor for processor_type, processor in self.available_processors.items() if not exclude_hidden or processor.is_hidden}
+			return {processor_type: processor for processor_type, processor in self.available_processors.items() if not exclude_hidden or not processor.is_hidden}
 
 		processors = self.get_compatible_processors(user=user)
 

--- a/webtool/templates/components/result-child.html
+++ b/webtool/templates/components/result-child.html
@@ -159,7 +159,7 @@
 
     {# 'More' button to show further analysis and preview #}
     <div class="processor-expand button-wrap">
-        {% if current_user.is_authenticated and item.is_finished() and (item.children or (item.num_rows > 0  and item.get_available_processors())) %}
+        {% if current_user.is_authenticated and item.is_finished() and (item.children or (item.num_rows > 0  and item.get_available_processors(exclude_hidden=True))) %}
         <button aria-controls="child-{{ item.key }}-details" class="toggle-button">
             <span class="headline">
             <i class="fa fa-sitemap" aria-hidden="true"></i> <span class="sr-only">More info</span>
@@ -184,7 +184,7 @@
         {# Possible further analyses #}
         {% if __user_config("privileges.can_run_processors") and (__user_config("privileges.admin.can_manipulate_all_datasets") or item.is_accessible_by(current_user, role="owner")) %}
         <ol class="children-processors">
-            {% for processor in item.get_available_processors().values() %}
+            {% for processor in item.get_available_processors(exclude_hidden=True).values() %}
 
                 {% set git_url = item.get_version_url("backend/processors/" + processor.filepath)%}
                 {% set dataset = item %}

--- a/webtool/templates/components/result-details.html
+++ b/webtool/templates/components/result-details.html
@@ -191,7 +191,7 @@
                 <p>See <a href="https://docs.google.com/document/d/1po-sOB8tDRZlvWrEayu97cGh_qsBuW0URd4md0_tv7k/edit?usp=sharing">this exercise sheet</a> for step-by-step tutorials.</p>
             </div>
             {% set cat = namespace(egory='') %}
-            {% for processor in dataset.get_available_processors().values() %}
+            {% for processor in dataset.get_available_processors(exclude_hidden=True).values() %}
                 {% if processor.category != cat.egory %}
                     {% if cat.egory != '' %}</ol>{% endif %}
                     {% set cat.egory = processor.category %}

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -1049,7 +1049,7 @@ def queue_processor(key=None, processor=None):
 		return error(403, error="You cannot run processors on private datasets")
 
 	# check if processor is available for this dataset
-	available_processors = dataset.get_available_processors(user=current_user)
+	available_processors = dataset.get_available_processors(user=current_user, ui_only=False)
 	if processor not in available_processors:
 		return error(404, error="This processor is not available for this dataset or has already been run.")
 

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -1049,7 +1049,7 @@ def queue_processor(key=None, processor=None):
 		return error(403, error="You cannot run processors on private datasets")
 
 	# check if processor is available for this dataset
-	available_processors = dataset.get_available_processors(user=current_user, ui_only=False)
+	available_processors = dataset.get_available_processors(user=current_user, exclude_hidden=True)
 	if processor not in available_processors:
 		return error(404, error="This processor is not available for this dataset or has already been run.")
 


### PR DESCRIPTION
Adds a parameter to DataSet.get_available_processors() to only return processors that ought to be visible in the UI and a method to BasicProcessor that can be True/False.

This works in the cartographer to hide the base downloaders and instead only display the presets (which run the downloaders plus a basic cartographer to display the images in the UI). But it should allow us to run other processors via either the API or presets without necessarily displaying them to users (such as the processor I built to export network points from our Sigma.js previewer).