### PR TITLE
Refactor module loading v2: move writing of module_config.bin to bootstrap

### DIFF
--- a/common/config_manager.py
+++ b/common/config_manager.py
@@ -2,16 +2,14 @@ import itertools
 import pickle
 import time
 import json
-
+import configparser
+import os
 from pathlib import Path
-from common.lib.database import Database
 
+from common.lib.database import Database
 from common.lib.exceptions import ConfigException
 from common.lib.config_definition import config_definition
 from common.lib.user_input import UserInput
-
-import configparser
-import os
 
 
 class ConfigManager:

--- a/common/lib/module_loader.py
+++ b/common/lib/module_loader.py
@@ -4,7 +4,6 @@ Load modules and datasources dynamically
 from pathlib import Path
 import importlib
 import inspect
-import pickle
 import sys
 import re
 
@@ -51,18 +50,6 @@ class ModuleCollector:
         # now we know all workers, we can add some extra metadata to the
         # datasources, e.g. whether they have an associated search worker
         self.expand_datasources()
-
-        # cache module-defined config options for use by the config manager
-        module_config = {}
-        for worker in self.workers.values():
-            if hasattr(worker, "config") and type(worker.config) is dict:
-                module_config.update(worker.config)
-
-        with config.get("PATH_ROOT").joinpath("config/module_config.bin").open("wb") as outfile:
-            pickle.dump(module_config, outfile)
-
-        # load from cache
-        config.load_user_settings()
 
     @staticmethod
     def is_4cat_class(object, only_processors=False):


### PR DESCRIPTION
I was looking over PR https://github.com/digitalmethodsinitiative/4cat/pull/396, updated it from the master, but ran into some issues. The "do not lazy load" commit (https://github.com/digitalmethodsinitiative/4cat/pull/396/commits/71ba7886cf514dec59bf47c68a25248477cf4fc1) causes failures since `self.modules` is often `None`. When I dove a bit deeper I became a little unsatisfied with how often ModuleCollector was being initialized and doing all that work. Before we would import the same instantiated object from `backends` instead of passing it around. I could do some more work here, but I think this PR's method may accomplish the same thing in a more simple fashion.

This PR only writes the `module_config.bin` in `bootstrap` and then updating the shared `config` object.

Both this solution and the other PR mean that the frontend will only have the latest data from `module_config.bin` if it is started after the backend. I do not believe this is a large problem as `module_config.bin` is only modified if code is updated (necessitating a restart of both anyway), but worth noting for 4CAT instances not managed by Docker as order becomes important.

As you are well aware, both PRs have an oddity in that all module classes are imported with a version of config that does not have the module configurations. The only place I noticed an effect was in `ModuleCollector.expand_datasources()` which calls `get_options()`. That method does often use config, but in `expand_datasources` we only care about _any options_ returning so there seems to be no issue. I note it in case something happens down the road related to this.