### PR TITLE
Export 4CAT datasets and analyses as ZIP file... and import them elsewhere!

### DIFF
--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import backend
 from common.config_manager import config
 from common.lib.job import Job, JobNotFoundException
-from common.lib.helpers import get_software_commit, NullAwareTextIOWrapper, convert_to_int
+from common.lib.helpers import get_software_commit, NullAwareTextIOWrapper, convert_to_int, get_software_version
 from common.lib.item_mapping import MappedItem, MissingMappedField, DatasetItem
 from common.lib.fourcat_module import FourcatModule
 from common.lib.exceptions import (ProcessorInterruptedException, DataSetException, DataSetNotFoundException,
@@ -1541,6 +1541,20 @@ class DataSet(FourcatModule):
 
 		# Default to text
 		return self.parameters.get("media_type", "text")
+
+	def get_metadata(self):
+		"""
+		Get dataset metadata
+
+		This consists of all the data stored in the database for this dataset, plus the current 4CAT version (appended
+		as 'current_4CAT_version'). This is useful for exporting datasets, as it can be used by another 4CAT instance to
+		update its database (and ensure compatibility with the exporting version of 4CAT).
+		"""
+		metadata = self.db.fetchone("SELECT * FROM datasets WHERE key = %s", (self.key,))
+
+		# get 4CAT version (presumably to ensure export is compatible with import)
+		metadata["current_4CAT_version"] = get_software_version()
+		return metadata
 
 	def get_result_url(self):
 		"""

--- a/processors/conversion/export_datasets.py
+++ b/processors/conversion/export_datasets.py
@@ -1,0 +1,100 @@
+"""
+Export a dataset and all its children to a ZIP file
+"""
+import shutil
+import json
+
+from backend.lib.processor import BasicProcessor
+from common.lib.dataset import DataSet
+from common.lib.exceptions import ProcessorException, DataSetException
+
+__author__ = "Dale Wahl"
+__credits__ = ["Dale Wahl"]
+__maintainer__ = "Dale Wahl"
+__email__ = "4cat@oilab.eu"
+
+
+
+class ExportDatasets(BasicProcessor):
+	"""
+	Export a dataset and all its children to a ZIP file
+	"""
+	type = "export-datasets"  # job type ID
+	category = "Conversion"  # category
+	title = "Export Dataset and All Analyses"  # title displayed in UI
+	description = "Creates a ZIP file containing the dataset and all analyses to be archived and uploaded to a 4CAT instance in the future"  # description displayed in UI
+	extension = "zip"  # extension of result file, used internally and in UI
+
+	@classmethod
+	def is_compatible_with(cls, module=None, user=None):
+		"""
+		Determine if processor is compatible with dataset
+
+		:param module: Module to determine compatibility with
+		"""
+		return module.is_top_dataset() and user.can_access_dataset(dataset=module, role="owner")
+
+	def process(self):
+		"""
+		This takes a CSV file as input and writes the same data as a JSON file
+		"""
+		self.dataset.update_status("Collecting dataset and all analyses")
+
+		results_path = self.dataset.get_staging_area()
+
+		exported_datasets = []
+		failed_exports = []  # keys that failed to import
+		keys = [self.dataset.top_parent().key] # get the key of the top parent
+		while keys:
+			dataset_key = keys.pop(0)
+			self.dataset.log(f"Exporting dataset {dataset_key}.")
+
+			try:
+				dataset = DataSet(key=dataset_key, db=self.db)
+			# TODO: these two should fail for the primary dataset, but should they fail for the children too?
+			except DataSetException:
+				self.dataset.finish_with_error("Dataset not found.")
+				return
+			if not dataset.is_finished():
+				self.dataset.finish_with_error("You cannot export unfinished datasets.")
+				return
+
+			# get metadata
+			metadata = dataset.get_metadata()
+			if metadata["num_rows"] == 0:
+				self.dataset.update_status(f"Skipping empty dataset {dataset_key}")
+				failed_exports.append(dataset_key)
+				continue
+
+			# get data
+			data_file = dataset.get_results_path()
+			if not data_file.exists():
+				self.dataset.finish_with_error(f"Dataset {dataset_key} has no data; skipping.")
+				failed_exports.append(dataset_key)
+				continue
+
+			# get log
+			log_file = dataset.get_results_path().with_suffix(".log")
+
+			# All good, add to ZIP
+			with results_path.joinpath(f"{dataset_key}_metadata.json").open("w", encoding="utf-8") as outfile:
+				outfile.write(json.dumps(metadata))
+			shutil.copy(data_file, results_path.joinpath(data_file.name))
+			if log_file.exists():
+				shutil.copy(log_file, results_path.joinpath(log_file.name))
+
+			# add children to queue
+			# Not using get_all_children() because we want to skip unfinished datasets and only need the keys
+			children = [d["key"] for d in self.db.fetchall("SELECT key FROM datasets WHERE key_parent = %s AND is_finished = TRUE", (dataset_key,))]
+			keys.extend(children)
+
+			self.dataset.update_status(f"Exported dataset {dataset_key}.")
+			exported_datasets.append(dataset_key)
+
+		# Add export log to ZIP
+		self.dataset.log(f"Exported datasets: {exported_datasets}")
+		self.dataset.log(f"Failed to export datasets: {failed_exports}")
+		shutil.copy(self.dataset.get_log_path(), results_path.joinpath("export.log"))
+
+		# done!
+		self.write_archive_and_finish(results_path, len(exported_datasets))

--- a/processors/conversion/export_datasets.py
+++ b/processors/conversion/export_datasets.py
@@ -3,10 +3,11 @@ Export a dataset and all its children to a ZIP file
 """
 import shutil
 import json
+import datetime
 
 from backend.lib.processor import BasicProcessor
 from common.lib.dataset import DataSet
-from common.lib.exceptions import ProcessorException, DataSetException
+from common.lib.exceptions import DataSetException
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -22,7 +23,7 @@ class ExportDatasets(BasicProcessor):
 	type = "export-datasets"  # job type ID
 	category = "Conversion"  # category
 	title = "Export Dataset and All Analyses"  # title displayed in UI
-	description = "Creates a ZIP file containing the dataset and all analyses to be archived and uploaded to a 4CAT instance in the future"  # description displayed in UI
+	description = "Creates a ZIP file containing the dataset and all analyses to be archived and uploaded to a 4CAT instance in the future. Automatically expires after 1 day, after which you must run again."  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
 
 	@classmethod
@@ -95,6 +96,11 @@ class ExportDatasets(BasicProcessor):
 		self.dataset.log(f"Exported datasets: {exported_datasets}")
 		self.dataset.log(f"Failed to export datasets: {failed_exports}")
 		shutil.copy(self.dataset.get_log_path(), results_path.joinpath("export.log"))
+
+		# set expiration date
+		# these datasets can be very large and are just copies of the existing datasets, so we don't need to keep them around for long
+		# TODO: convince people to stop using hyphens in python variables and file names...
+		self.dataset.__setattr__("expires-after", (datetime.datetime.now() + datetime.timedelta(days=1)).timestamp())
 
 		# done!
 		self.write_archive_and_finish(results_path, len(exported_datasets))

--- a/webtool/views/api_tool.py
+++ b/webtool/views/api_tool.py
@@ -1237,11 +1237,7 @@ def export_packed_dataset(key=None, component=None):
 		return error(403, error="You cannot export unfinished datasets.")
 
 	if component == "metadata":
-		metadata = db.fetchone("SELECT * FROM datasets WHERE key = %s", (dataset.key,))
-
-		# get 4CAT version (presumably to ensure export is compatible with import)
-		metadata["current_4CAT_version"] = get_software_version()
-		return jsonify(metadata)
+		return jsonify(dataset.get_metadata())
 
 	elif component == "children":
 		children = [d["key"] for d in db.fetchall("SELECT key FROM datasets WHERE key_parent = %s AND is_finished = TRUE", (dataset.key,))]


### PR DESCRIPTION
-  Processor that saves metadata, results files, and logs into a zip file.
    -  Automatically expires after 1 day (as these datasets are essentially just copies of the other data)
-  Updates to import_4cat datasource to accept ZIP files in addition to 4CAT results URLs