### PR TITLE
Add check and reconnect method to Database class

### DIFF
--- a/common/lib/database.py
+++ b/common/lib/database.py
@@ -49,23 +49,33 @@ class Database:
 		if self.log is None:
 			self.log = logging
 
-		self.commit()
-
-	def check_and_reconnect(self):
+	def check_and_reconnect(self, tries=3, wait=10):
 		"""
         Check if the connection is closed and reconnect if necessary.
+
+        :param int tries: Number of tries to reconnect
+        :param int wait: Time to wait between tries (first try is immediate)
         """
 		try:
 			self.connection.cursor().execute('SELECT 1')
 		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
 			self.log.warning(f"Database connection closed. Reconnecting...\n{e}")
-			self.connection = psycopg2.connect(dbname=self.connection.info.dbname,
-											   user=self.connection.info.user,
-											   password=self.connection.info.password,
-											   host=self.connection.info.host,
-											   port=self.connection.info.port,
-											   application_name=self.appname)
-			self.cursor = self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+			current = 1
+			while current <= tries:
+				try:
+					self.connection = psycopg2.connect(dbname=self.connection.info.dbname,
+													   user=self.connection.info.user,
+													   password=self.connection.info.password,
+													   host=self.connection.info.host,
+													   port=self.connection.info.port,
+													   application_name=self.appname)
+					self.cursor = self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+					break
+				except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+					self.log.warning(f"Database connection closed. Reconnecting...\n{e}")
+					time.sleep(wait)
+					current += 1
+
 
 	def query(self, query, replacements=None, cursor=None):
 		"""

--- a/common/lib/database.py
+++ b/common/lib/database.py
@@ -56,7 +56,6 @@ class Database:
 		:param int tries: Number of tries to reconnect
         :param int wait: Time to wait between tries (first try is immediate)
 		"""
-		self.log.warning("Reconnecting to database...")
 		for i in range(tries):
 			try:
 				self.connection = psycopg2.connect(dbname=self.connection.info.dbname,
@@ -88,6 +87,7 @@ class Database:
 		try:
 			cursor.execute(query, replacements)
 		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+			self.log.warning(f"Database Exception: {e}\nReconnecting and retrying query...")
 			self.reconnect()
 			cursor = self.get_cursor()
 			cursor.execute(query, replacements)
@@ -131,6 +131,7 @@ class Database:
 		try:
 			execute_values(cursor, query, replacements)
 		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+			self.log.warning(f"Database Exception: {e}\nReconnecting and retrying query...")
 			self.reconnect()
 			cursor = self.get_cursor()
 			execute_values(cursor, query, replacements)
@@ -430,6 +431,7 @@ class Database:
 		"""
 		try:
 			return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-		except (psycopg2.InterfaceError, psycopg2.OperationalError):
+		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+			self.log.warning(f"Database Exception: {e}\nReconnecting and retrying query...")
 			self.reconnect()
 			return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)

--- a/common/lib/database.py
+++ b/common/lib/database.py
@@ -49,33 +49,28 @@ class Database:
 		if self.log is None:
 			self.log = logging
 
-	def check_and_reconnect(self, tries=3, wait=10):
+	def reconnect(self, tries=3, wait=10):
 		"""
-        Check if the connection is closed and reconnect if necessary.
+		Reconnect to the database
 
-        :param int tries: Number of tries to reconnect
+		:param int tries: Number of tries to reconnect
         :param int wait: Time to wait between tries (first try is immediate)
-        """
-		try:
-			self.connection.cursor().execute('SELECT 1')
-		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
-			self.log.warning(f"Database connection closed. Reconnecting...\n{e}")
-			current = 1
-			while current <= tries:
-				try:
-					self.connection = psycopg2.connect(dbname=self.connection.info.dbname,
-													   user=self.connection.info.user,
-													   password=self.connection.info.password,
-													   host=self.connection.info.host,
-													   port=self.connection.info.port,
-													   application_name=self.appname)
-					self.cursor = self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-					break
-				except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
-					self.log.warning(f"Database connection closed. Reconnecting...\n{e}")
-					time.sleep(wait)
-					current += 1
-
+		"""
+		self.log.warning("Reconnecting to database...")
+		for i in range(tries):
+			try:
+				self.connection = psycopg2.connect(dbname=self.connection.info.dbname,
+												   user=self.connection.info.user,
+												   password=self.connection.info.password,
+												   host=self.connection.info.host,
+												   port=self.connection.info.port,
+												   application_name=self.appname)
+				self.cursor = self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+				return
+			except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+				self.log.warning(f"Database connection closed. Reconnecting...\n{e}")
+				time.sleep(wait)
+		self.log.error("Failed to reconnect to database after %d tries" % tries)
 
 	def query(self, query, replacements=None, cursor=None):
 		"""
@@ -88,28 +83,38 @@ class Database:
 		"""
 		if not cursor:
 			cursor = self.get_cursor()
-		else:
-			self.check_and_reconnect()
 
-		self.log.debug("Executing query %s" % self.cursor.mogrify(query, replacements))
+		self.log.debug("Executing query %s" % cursor.mogrify(query, replacements))
+		try:
+			cursor.execute(query, replacements)
+		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+			self.reconnect()
+			cursor = self.get_cursor()
+			cursor.execute(query, replacements)
+		return cursor
 
-		return cursor.execute(query, replacements)
-
-	def execute(self, query, replacements=None):
+	def execute(self, query, replacements=None, commit=True, cursor=None, close_cursor=True):
 		"""
 		Execute a query, and commit afterwards
 
 		This is required for UPDATE/INSERT/DELETE/etc to stick
 		:param string query:  Query
+		:param cursor: Cursor to use. Default - use get_cursor method for common cursor
 		:param replacements: Replacement values
+		:param bool commit:  Commit transaction after query?
+		:param bool close_cursor:  Close cursor after query?
 		"""
-		cursor = self.get_cursor()
+		cursor = self.query(query, replacements, cursor)
 
-		self.log.debug("Executing query %s" % self.cursor.mogrify(query, replacements))
-		cursor.execute(query, replacements)
-		self.commit()
+		if commit:
+			self.commit()
 
-		cursor.close()
+		rowcount = cursor.rowcount
+
+		if close_cursor:
+			cursor.close()
+
+		return rowcount
 
 	def execute_many(self, query, commit=True, replacements=None):
 		"""
@@ -123,7 +128,13 @@ class Database:
 		:param commit:  Commit transaction after query?
 		"""
 		cursor = self.get_cursor()
-		execute_values(cursor, query, replacements)
+		try:
+			execute_values(cursor, query, replacements)
+		except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+			self.reconnect()
+			cursor = self.get_cursor()
+			execute_values(cursor, query, replacements)
+
 		cursor.close()
 		if commit:
 			self.commit()
@@ -156,16 +167,8 @@ class Database:
 
 		query = sql.SQL(query).format(*identifiers)
 
-		cursor = self.get_cursor()
-		self.log.debug("Executing query: %s" % cursor.mogrify(query, replacements))
-		cursor.execute(query, replacements)
-
-		if commit:
-			self.commit()
-
-		result = cursor.rowcount
-		cursor.close()
-		return result
+		rowcount = self.execute(query, replacements=replacements, commit=commit)
+		return rowcount
 
 	def delete(self, table, where, commit=True):
 		"""
@@ -192,16 +195,8 @@ class Database:
 		identifiers.insert(0, sql.Identifier(table))
 		query = sql.SQL("DELETE FROM {} WHERE " + " AND ".join(where_sql)).format(*identifiers)
 
-		cursor = self.get_cursor()
-		self.log.debug("Executing query: %s" % cursor.mogrify(query, replacements))
-		cursor.execute(query, replacements)
-
-		if commit:
-			self.commit()
-
-		result = cursor.rowcount
-		cursor.close()
-		return result
+		rowcount = self.execute(query, replacements=replacements, commit=commit)
+		return rowcount
 
 	def insert(self, table, data, commit=True, safe=False, constraints=None, return_field=""):
 		"""
@@ -247,13 +242,9 @@ class Database:
 		replacements = (tuple(data.values()),)
 
 		cursor = self.get_cursor()
-		self.log.debug("Executing query: %s" % cursor.mogrify(query, replacements))
-		cursor.execute(query, replacements)
+		rowcount = self.execute(query, replacements=replacements, cursor=cursor, commit=commit, close_cursor=False)
 
-		if commit:
-			self.commit()
-
-		result = cursor.rowcount if not return_field else cursor.fetchone()[return_field]
+		result = rowcount if not return_field else cursor.fetchone()[return_field]
 		cursor.close()
 		return result
 
@@ -293,16 +284,8 @@ class Database:
 		query = sql.SQL(protoquery).format(*identifiers)
 		replacements = (tuple(data.values()),)
 
-		cursor = self.get_cursor()
-		self.log.debug("Executing query: %s" % cursor.mogrify(query, replacements))
-		cursor.execute(query, replacements)
-
-		if commit:
-			self.commit()
-
-		result = cursor.rowcount
-		cursor.close()
-		return result
+		rowcount = self.execute(query, replacements=replacements, commit=commit)
+		return rowcount
 
 	def fetchall(self, query, *args):
 		"""
@@ -313,9 +296,7 @@ class Database:
 		:param commit:  Commit transaction after query?
 		:return list: The result rows, as a list
 		"""
-		cursor = self.get_cursor()
-		self.log.debug("Executing query: %s" % cursor.mogrify(query, *args))
-		self.query(query, cursor=cursor, *args)
+		cursor = self.query(query, *args)
 
 		try:
 			result = cursor.fetchall()
@@ -344,8 +325,7 @@ class Database:
 		:param commit:  Commit transaction after query?
 		:return: The row, as a dictionary, or None if there were no rows
 		"""
-		cursor = self.get_cursor()
-		self.query(query, cursor=cursor, *args)
+		cursor = self.query(query, *args)
 
 		try:
 			result = cursor.fetchone()
@@ -387,12 +367,10 @@ class Database:
 		pid = self.connection.get_backend_pid()
 		self.interruptable_job = queue.add_job("cancel-pg-query", details={}, remote_id=self.appname, claim_after=time.time() + self.interruptable_timeout)
 
-		# make the query
+		# run the query
 		cursor = self.get_cursor()
-		self.log.debug("Executing interruptable query: %s" % cursor.mogrify(query, *args))
-
 		try:
-			self.query(query, cursor=cursor, *args)
+			cursor = self.query(query, cursor=cursor, *args)
 		except psycopg2.extensions.QueryCanceledError:
 			# interrupted with cancellation worker (or manually)
 			self.log.debug("Query in connection %s was interrupted..." % self.appname)
@@ -450,5 +428,8 @@ class Database:
 
 		:return: Cursor
 		"""
-		self.check_and_reconnect()
-		return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+		try:
+			return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+		except (psycopg2.InterfaceError, psycopg2.OperationalError):
+			self.reconnect()
+			return self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)


### PR DESCRIPTION
This would allow the Database class to reconnect on SSL errors or recover if the connection was closed. If we run a bad query it will not recover from `psycopg2.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block` and require a rollback.

I tested it by shutting down the database, attempting to run some processes (which obviously failed), and then restarting the database. It seemed to recover just fine (well, any processors that failed would not restart until we restart the backend, but the frontend recovered fine).