### PR TITLE
Add example DataSet keys to Data Source page

### DIFF
--- a/common/lib/helpers.py
+++ b/common/lib/helpers.py
@@ -46,6 +46,17 @@ def init_datasource(database, logger, queue, name):
     """
     pass
 
+def get_datasource_example_keys(db, modules, dataset_type):
+    """
+    Get example keys for a datasource
+    """
+    from common.lib.dataset import DataSet
+    example_dataset_key = db.fetchone("SELECT key from datasets WHERE type = %s and is_finished = True and num_rows > 0 LIMIT 1", (dataset_type,))
+    if example_dataset_key:
+        example_dataset = DataSet(db=db, key=example_dataset_key["key"], modules=modules)
+        return example_dataset.get_columns()
+    return []
+
 def strip_tags(html, convert_newlines=True):
     """
     Strip HTML from a string

--- a/common/lib/helpers.py
+++ b/common/lib/helpers.py
@@ -51,7 +51,7 @@ def get_datasource_example_keys(db, modules, dataset_type):
     Get example keys for a datasource
     """
     from common.lib.dataset import DataSet
-    example_dataset_key = db.fetchone("SELECT key from datasets WHERE type = %s and is_finished = True and num_rows > 0 LIMIT 1", (dataset_type,))
+    example_dataset_key = db.fetchone("SELECT key from datasets WHERE type = %s and is_finished = True and num_rows > 0 ORDER BY timestamp_finished DESC LIMIT 1", (dataset_type,))
     if example_dataset_key:
         example_dataset = DataSet(db=db, key=example_dataset_key["key"], modules=modules)
         return example_dataset.get_columns()

--- a/webtool/templates/data-overview.html
+++ b/webtool/templates/data-overview.html
@@ -95,6 +95,18 @@
                         </dd>
                     </div>
                     {% endif %}
+                    {% if example_keys %}
+                    <div class="fullwidth">
+                        <dt>DataSet keys</dt>
+                        <dd>
+                            <ul class="nobullet">
+                            {% for key in example_keys %}
+                                <span class="inline-label property-badge">{{ key }}</span>
+                            {% endfor %}
+                            </ul>
+                        </dd>
+                    </div>
+                    {% endif %}
                 </dl>
             </div>
             {% else %}

--- a/webtool/views/views_misc.py
+++ b/webtool/views/views_misc.py
@@ -17,6 +17,7 @@ from webtool.lib.helpers import pad_interval, error
 from webtool.views.views_dataset import create_dataset, show_results
 
 from common.config_manager import ConfigWrapper
+from common.lib.helpers import get_datasource_example_keys
 config = ConfigWrapper(config, user=current_user, request=request)
 
 csv.field_size_limit(1024 * 1024 * 1024)
@@ -129,6 +130,7 @@ def data_overview(datasource=None):
     daily_counts = None
     references = None
     labels = None
+    example_keys = None
 
     if datasource:
 
@@ -155,6 +157,10 @@ def data_overview(datasource=None):
 
         if hasattr(worker_class, "is_from_zeeschuimer"):
             labels.append("zeeschuimer")
+
+        # Get example keys for the datasource
+        if datasource_id not in ["upload"]: # ignore upload as keys are variable
+            example_keys = get_datasource_example_keys(db=db, modules=fourcat_modules, dataset_type=datasource_id + "-search")
 
         # Get daily post counts for local datasource to display in a graph
         if is_local == "local":
@@ -185,7 +191,7 @@ def data_overview(datasource=None):
 
         references = worker_class.references if hasattr(worker_class, "references") else None        
 
-    return render_template('data-overview.html', datasources=datasources, datasource_id=datasource_id, description=description, labels=labels, total_counts=total_counts, daily_counts=daily_counts, github_url=github_url, references=references)
+    return render_template('data-overview.html', datasources=datasources, datasource_id=datasource_id, description=description, labels=labels, total_counts=total_counts, daily_counts=daily_counts, github_url=github_url, references=references, example_keys=example_keys)
 
 @app.route('/get-boards/<string:datasource>/')
 @login_required


### PR DESCRIPTION
There was a question about listing the data collected for each Data Source and I thought this an easy way to at least list the available keys. This relies on an example dataset existing and `map_item`.

It could be further helpful if we had explanations for each key, but that would be manual and have to be maintained. It also would be beneficial if it was most public (perhaps in the Wiki or on 4cat.nl).

![image](https://github.com/user-attachments/assets/9c25ae6e-5736-466d-adac-fea32e81016d)