### PR TITLE
Slimcat: shrink size of 4cat image

### DIFF
--- a/docker-compose_build.yml
+++ b/docker-compose_build.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   backend:
-    image: 4cat
+    image: 4cat:slim
     build:
       context: .
       dockerfile: docker/Dockerfile_slim
@@ -37,7 +37,7 @@ services:
     entrypoint: docker/docker-entrypoint.sh
 
   frontend:
-    image: 4cat
+    image: 4cat:slim
     container_name: 4cat_frontend
     env_file:
       - .env

--- a/docker-compose_build.yml
+++ b/docker-compose_build.yml
@@ -8,8 +8,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_HOST_AUTH_METHOD=${POSTGRES_HOST_AUTH_METHOD}
     volumes:
-      - ./data/postgres/:/var/lib/postgresql/data/
-      # - 4cat_db:/var/lib/postgresql/data/
+      # - ./data/postgres/:/var/lib/postgresql/data/
+      - 4cat_db:/var/lib/postgresql/data/
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER}" ]
       interval: 5s
@@ -20,7 +20,7 @@ services:
     image: 4cat
     build:
       context: .
-      dockerfile: docker/Dockerfile
+      dockerfile: docker/Dockerfile_slim
     container_name: 4cat_backend
     env_file:
       - .env
@@ -28,12 +28,12 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./data/datasets/:/usr/src/app/data/
-      - ./data/config/:/usr/src/app/config/
-      - ./data/logs/:/usr/src/app/logs/
-      # - 4cat_data:/usr/src/app/data/
-      # - 4cat_config:/usr/src/app/config/
-      # - 4cat_logs:/usr/src/app/logs/
+      # - ./data/datasets/:/usr/src/app/data/
+      # - ./data/config/:/usr/src/app/config/
+      # - ./data/logs/:/usr/src/app/logs/
+      - 4cat_data:/usr/src/app/data/
+      - 4cat_config:/usr/src/app/config/
+      - 4cat_logs:/usr/src/app/logs/
     entrypoint: docker/docker-entrypoint.sh
 
   frontend:
@@ -48,12 +48,12 @@ services:
       - ${SERVER_BIND_ADDRESS}:${PUBLIC_PORT}:5000
       - ${TELEGRAM_PORT}:443
     volumes:
-      - ./data/datasets/:/usr/src/app/data/
-      - ./data/config/:/usr/src/app/config/
-      - ./data/logs/:/usr/src/app/logs/
-      # - 4cat_data:/usr/src/app/data/
-      # - 4cat_config:/usr/src/app/config/
-      # - 4cat_logs:/usr/src/app/logs/
+      # - ./data/datasets/:/usr/src/app/data/
+      # - ./data/config/:/usr/src/app/config/
+      # - ./data/logs/:/usr/src/app/logs/
+      - 4cat_data:/usr/src/app/data/
+      - 4cat_config:/usr/src/app/config/
+      - 4cat_logs:/usr/src/app/logs/
     command: ["docker/wait-for-backend.sh"]
 
 volumes:

--- a/docker/Dockerfile_slim
+++ b/docker/Dockerfile_slim
@@ -100,6 +100,4 @@ RUN chmod +x docker/wait-for-backend.sh docker/docker-entrypoint.sh
 RUN find /usr/src/app -name "*.pyc" -delete && \
     find /usr/src/app -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/src/app -name "*.pyo" -delete && \
-    find /usr/src/app -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true && \
-    find /usr/src/app -name ".pytest_cache" -type d -exec rm -rf {} + 2>/dev/null || true && \
-    find /usr/src/app -name "tests" -type d -exec rm -rf {} + 2>/dev/null || true
+    find /usr/src/app -name ".pytest_cache" -type d -exec rm -rf {} + 2>/dev/null || true 

--- a/docker/Dockerfile_slim
+++ b/docker/Dockerfile_slim
@@ -1,0 +1,105 @@
+# Multi-stage build for 4CAT - Slim version
+# Stage 1: Build stage with all build dependencies
+FROM python:3.11-slim as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    # Build tools
+    build-essential \
+    gcc \
+    g++ \
+    # Development headers
+    libpq-dev \
+    python3-dev \
+    postgresql-server-dev-all \
+    # Git for any git-based dependencies
+    git \
+    # Additional build dependencies that might be needed
+    pkg-config \
+    libffi-dev \
+    libssl-dev \
+    # Clean up cache
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /usr/src/app
+
+# Set environment variables for building
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Copy requirements and setup files first
+COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./setup.py /usr/src/app/setup.py
+COPY ./VERSION /usr/src/app/VERSION
+COPY ./README.md /usr/src/app/README.md
+
+# Copy only the extensions directory for dependency detection
+COPY ./extensions /usr/src/app/extensions
+
+# Create minimal directory structure that setup.py expects
+RUN mkdir -p /usr/src/app/backend /usr/src/app/webtool /usr/src/app/datasources
+RUN touch /usr/src/app/backend/__init__.py /usr/src/app/webtool/__init__.py /usr/src/app/datasources/__init__.py
+
+# Install Python dependencies to a virtual environment
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Upgrade pip and install wheel first
+RUN pip install --upgrade pip
+
+# Install build dependencies for Python packages
+RUN pip install --no-cache-dir setuptools==78.1.0 wheel==0.46.1
+
+# Install requirements with verbose output for debugging
+RUN pip install --no-cache-dir --verbose -r requirements.txt
+
+# Install gunicorn
+RUN pip install --no-cache-dir gunicorn
+
+# Stage 2: Runtime stage with minimal dependencies
+FROM python:3.11-slim as runtime
+
+# Install only runtime dependencies
+RUN apt-get update && apt-get install -y \
+    # Runtime libraries only
+    libpq5 \
+    # Tools needed at runtime
+    curl \
+    netcat-traditional \
+    postgresql-client \
+    # Git for application use
+    git \
+    # Video processing (if needed)
+    #ffmpeg \
+    # Clean up
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/*
+
+# Copy virtual environment from builder stage
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Set working directory
+WORKDIR /usr/src/app
+
+# Ensure Python outputs everything
+ENV PYTHONUNBUFFERED=1
+
+# Copy application code
+COPY . /usr/src/app/
+
+# Set permissions for scripts
+RUN chmod +x docker/wait-for-backend.sh docker/docker-entrypoint.sh
+
+# Remove unnecessary files to save space
+RUN find /usr/src/app -name "*.pyc" -delete && \
+    find /usr/src/app -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true && \
+    find /usr/src/app -name "*.pyo" -delete && \
+    find /usr/src/app -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true && \
+    find /usr/src/app -name ".pytest_cache" -type d -exec rm -rf {} + 2>/dev/null || true && \
+    find /usr/src/app -name "tests" -type d -exec rm -rf {} + 2>/dev/null || true


### PR DESCRIPTION
### Create working 4cat:slim image
Deploy via `docker compose -f docker-compose_build.yml up -d --build`

Currently the 4cat:stable image is 4.73 GB on the drive. The image from `Docker_slim` reduces that to 2.06 GB. 

### Breakdown:
-  Base Docker image (i.e. `python:3.11-slim` ): 195MB
-  Python packages (`/opt/venv/`): 1.1 GB
-  4CAT application: 70 MB
- Additional linux packages: 114 MB
  -  Including `/usr/lib/x86_64-linux-gnu`: 85MB which could perhaps be reduced

I already removed ffmpeg (it was ~400 MB). Additional reductions seem unlikely without reviewing python packages.

### Issues
There are some consequences here. Mainly that we lose the ability to upgrade python environments. With Docker, that is not so bad a deal as you can download a previously created image with the appropriate environment.

Some maintenance will need to be done to test and ensure this image works with all environment changes. Processors using certain features (e.g., ffmpeg) need to be disabled.

Known To-do:
-  `migrate.py` will not work in its current form; it would need to be modified or circumvented. Ideally modified so that the environment and code base could be maintained/updated via Docker, but any necessary migrate scripts (for such things as database changes) could still be run.
- Disable some frontend features such as update and update to branch.
  - Restarting the frontend also does not currently work, but that does not feel related

### Question
Is the reduction of 2.6 gigs worth it? Is container size the real user bottleneck? 