### PR TITLE
Notifications from notification server

### DIFF
--- a/backend/database.sql
+++ b/backend/database.sql
@@ -167,10 +167,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS unique_favourite
 -- notifications
 CREATE TABLE IF NOT EXISTS users_notifications (
     id                  SERIAL PRIMARY KEY,
+    canonical_id        TEXT DEFAULT '',
     username            TEXT,
     notification        TEXT,
+    notification_long   TEXT DEFAULT '',
     timestamp_expires   INTEGER,
-    allow_dismiss       BOOLEAN DEFAULT TRUE
+    allow_dismiss       BOOLEAN DEFAULT TRUE,
+    is_dismissed        BOOLEAN DEFAULT FALSE
 );
 
 CREATE INDEX IF NOT EXISTS users_notifications_name
@@ -180,7 +183,7 @@ CREATE INDEX IF NOT EXISTS users_notifications_name
 
 CREATE UNIQUE INDEX IF NOT EXISTS users_notifications_unique
   ON users_notifications (
-    username, notification
+    canonical_id, username, notification
   );
 
 -- used to quickly update table counts

--- a/backend/lib/manager.py
+++ b/backend/lib/manager.py
@@ -114,7 +114,7 @@ class WorkerManager:
 						job.claim()
 						worker = worker_class(logger=self.log, manager=self, job=job, modules=self.modules)
 						worker.start()
-						self.log.info(f"Starting new worker of for job {job.data['jobtype']}/{job.data['remote_id']}")
+						self.log.info(f"Starting new worker for job {job.data['jobtype']}/{job.data['remote_id']}")
 						self.worker_pool[jobtype].append(worker)
 					except JobClaimedException:
 						# it's fine

--- a/common/lib/config_definition.py
+++ b/common/lib/config_definition.py
@@ -208,9 +208,10 @@ config_definition = {
         "type": UserInput.OPTION_TEXT,
         "default": "https://ping.4cat.nl",
         "help": "Phone home URL",
-        "tooltip": "This URL is called once - when 4CAT is installed. If the installing user consents, information "
-                   "is sent to this URL to help the 4CAT developers (the Digital Methods Initiative) keep track of how "
-                   "much it is used. There should be no need to change this URL after installation.",
+        "tooltip": "This URL is called when 4CAT is installed, if the user consents, to help the 4CAT developers (the "
+                   "Digital Methods Initiative) keep track of how much it is used. Later, notifications for 4CAT "
+                   "admins are fetched from this URL to inform them about important changes and update procedures. If "
+                   "you want to disable this functionality, leave this field empty.",
         "global": True
     },
     "4cat.phone_home_asked": {

--- a/helper-scripts/migrate/migrate-1.50-1.51.py
+++ b/helper-scripts/migrate/migrate-1.50-1.51.py
@@ -1,0 +1,52 @@
+# Update the 'annotations' table so every annotation has its own row.
+# also add extra data
+import sys
+import os
+
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), "../.."))
+from common.lib.database import Database
+from common.lib.logger import Logger
+
+import configparser
+
+log = Logger(output=True)
+ini = configparser.ConfigParser()
+ini.read(Path(__file__).parent.parent.parent.resolve().joinpath("config/config.ini"))
+db_config = ini["DATABASE"]
+
+db = Database(logger=log, dbname=db_config["db_name"], user=db_config["db_user"], password=db_config["db_password"],
+              host=db_config["db_host"], port=db_config["db_port"], appname="4cat-migrate")
+
+print("  Adding `from_dataset` column to annotations table...")
+# Original annotations table had columns 'key' and 'annotations', new annotations has 'dataset' among others
+has_column = db.fetchone("SELECT COUNT(*) AS num FROM information_schema.columns WHERE table_name = 'annotations' AND column_name = 'from_dataset'")
+
+# Ensure we do not attempt to update the annotations table if it has already been updated
+# This will drop the annotations table and create a new one losing all annotations
+# (both backend and frontend run migrate.py in case they have to update different aspects)
+if has_column["num"] > 0:
+    print("    Annotations table seems to have been updated already")
+else:
+    print("    Annotations table needs to be updated")
+    db.execute("ALTER TABLE annotations ADD from_dataset TEXT")
+
+
+print("    Creating indexes for `from_dataset` and unique fields for the annotations table...")
+db.execute("""
+CREATE INDEX IF NOT EXISTS annotations_from_dataset
+ON annotations (
+    from_dataset
+);
+DROP INDEX IF EXISTS annotation_unique;
+DROP INDEX IF EXISTS annotation_value;
+CREATE UNIQUE INDEX annotation_unique
+ON annotations (
+    dataset,
+    item_id,
+    field_id
+);
+""")
+
+print("  - done!")

--- a/webtool/__init__.py
+++ b/webtool/__init__.py
@@ -216,6 +216,7 @@ with app.app_context():
         g.log = log
         g.config = ConfigWrapper(app.fourcat_config, user=current_user, request=request)
         g.modules = current_app.fourcat_modules
+        g.request = request
 
         current_user.with_config(g.config)
 

--- a/webtool/lib/template_filters.py
+++ b/webtool/lib/template_filters.py
@@ -426,6 +426,7 @@ def inject_now():
 		"__notifications": current_user.get_notifications(),
 		"__user_config": lambda setting: g.config.get(setting),
 		"__config": g.config,
+		"__request": g.request,
 		"__user_cp_access": any([g.config.get(p) for p in g.config.config_definition.keys() if p.startswith("privileges.admin")]),
 		"__version": version,
 		"uniqid": uniqid

--- a/webtool/templates/account/notification.html
+++ b/webtool/templates/account/notification.html
@@ -1,0 +1,26 @@
+{% extends "layout.html" %}
+
+{% block title %}View notification{% endblock %}
+{% block body_class %}plain-page markdown-page {{ body_class }}{% endblock %}
+
+{% block body %}
+    <article>
+        <section>
+            <h2>Notification</h2>
+            {{ notification.notification_long|markdown|safe }}
+
+            {% if not notification.is_dismissed %}
+            <form action="{{ url_for('user.dismiss_notification', notification_id=notification.id) }}" method="POST" class="wide">
+                <div class="submit-container">
+                    <input type="hidden" name="redirect" value="{{ __request.referrer }}">
+                    <button>
+                        <i class="fa fa-times" aria-hidden="true"></i> Dismiss notification
+                    </button>
+                </div>
+            </form>
+            {% else %}
+                <p><i>This notification was dismissed and will be deleted automatically when it expires on the 4CAT update server.</i></p>
+            {% endif %}
+        </section>
+    </article>
+{% endblock %}

--- a/webtool/templates/controlpanel/notifications-list.html
+++ b/webtool/templates/controlpanel/notifications-list.html
@@ -17,12 +17,22 @@
                     <td>
                         {% if notification.timestamp_expires %}
                             <i class="fa fa-clock tooltip-trigger" aria-controls="tooltip-expires-{{ notification.id }}" aria-hidden="true"></i><span class="sr-only">Notification will expire at {{ notification.timestamp_expires|datetime("%-d %b %Y %H:%M", wrap=True) }}</span>
-                            <p role="tooltip" class="multiple" id="tooltip-expires-{{ notification.id }}" aria-hidden="true">Notification will expire at {{ notification.timestamp_expires|datetime("%-d %b %Y %H:%M", wrap=False) }}</p>
+                            <p role="tooltip" id="tooltip-expires-{{ notification.id }}" aria-hidden="true">Notification will expire at {{ notification.timestamp_expires|datetime("%-d %b %Y %H:%M", wrap=False) }}</p>
                         {% endif %}
                         <span class="has-more" data-max-length="75">{{ notification.notification|markdown|safe }}</span>
+                        {% if notification.notification_long %}
+                            (<a href="{{ url_for("user.view_notification", notification_id=notification.id) }}">read more...</a>)
+                        {% endif %}
                     </td>
-                    <td><a class="button-like" href="{{ url_for("admin.delete_notification", notification_id=notification.id) }}"><i
+                    <td>
+                        {% if notification.canonical_id %}
+                            <i class="fa fa-globe tooltip-trigger" aria-hidden="true" aria-controls="tooltip-remote-{{ notification.id }}"></i>
+                            <p role="tooltip" id="tooltip-remote-{{ notification.id }}" aria-hidden="true">This notification was received from the 4CAT update server and cannot be deleted, only dismissed. It will disappear automatically when it is deleted remotely.</p>
+                        {% else %}
+                        <a class="button-like" href="{{ url_for("admin.delete_notification", notification_id=notification.id) }}"><i
                                     class="fa fa-times" aria-hidden="true"></i><span class="sr-only">Delete notification</span></a>
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         {% else %}

--- a/webtool/templates/layout.html
+++ b/webtool/templates/layout.html
@@ -63,6 +63,9 @@
     {% for notification in __notifications %}
         <div class="site-announcement">
             {{ notification.notification|markdown|safe }}
+            {% if notification.notification_long %}
+                (<a href="{{ url_for("user.view_notification", notification_id=notification.id) }}">read more...</a>)
+            {% endif %}
             {% if notification.allow_dismiss %}
                 <a href="{{ url_for("user.dismiss_notification", notification_id=notification.id) }}"><i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">Dismiss notification</span></a>
             {% endif %}

--- a/webtool/templates/page.html
+++ b/webtool/templates/page.html
@@ -6,7 +6,7 @@
 {% block body %}
     <article>
         <section>
-            {{ body_content|safe }}
+            {{ notification.notification_long|safe }}
         </section>
     </article>
 {% endblock %}

--- a/webtool/views/views_user.py
+++ b/webtool/views/views_user.py
@@ -550,12 +550,20 @@ def show_access_tokens():
 
     return render_template("access-tokens.html", tokens=tokens)
 
-@component.route("/dismiss-notification/<int:notification_id>")
+@component.route("/view-notification/<int:notification_id>")
+def view_notification(notification_id):
+    notification = g.db.fetchone("SELECT * FROM users_notifications WHERE id = %s", (notification_id,))
+    if not notification:
+        return render_template("error.html", message="No such notification."), 404
+
+    return render_template("account/notification.html", notification=notification)
+
+@component.route("/dismiss-notification/<int:notification_id>", methods=["GET", "POST"])
 def dismiss_notification(notification_id):
     current_user.dismiss_notification(notification_id)
 
     if not request.args.get("async"):
-        redirect_url = request.headers.get("Referer")
+        redirect_url = request.form.get("redirect") or request.headers.get("Referer")
         if not redirect_url:
             redirect_url = url_for("misc.show_frontpage")
 


### PR DESCRIPTION
Allows for remotely sourced notifications. The 'check for updates' worker already called GitHub to see if new 4CAT versions were available. It now also calls the 'phone home URL' configured in 4CAT to fetch further notifications, which can e.g. be used to inform 4CAT admins about upgrades that require extra steps (such as rebuilding Docker containers) or to send alerts about security issues.

Adds some columns to the `user_notifications_table`; a notification can now link to a page containing a longer version of its content. Remotely sourced notifications are not deleted when dismissed but just marked as 'dismissed' (and hidden from the user), to avoid a situation where the notification continuously gets added again when the notification server is queried. Once a dismissed remote notification is no longer present on the server, it is also deleted from the local database.