### PR TITLE
Don't copy over over *all* annotations when filtering

### DIFF
--- a/backend/lib/processor.py
+++ b/backend/lib/processor.py
@@ -696,7 +696,7 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
         if finish:
             self.dataset.finish(num_items)
 
-    def create_standalone(self):
+    def create_standalone(self, item_ids=None):
         """
         Copy this dataset and make that copy standalone.
 
@@ -705,8 +705,11 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
         
         This also transfers annotations and annotation fields.
 
+        :param list item_ids:   The item_ids that are copied-over. Used to check what annotations need to be copied.
+
         :return DataSet:  The new standalone dataset
         """
+
         top_parent = self.source_dataset
 
         finished = self.dataset.check_dataset_finished()
@@ -720,30 +723,34 @@ class BasicProcessor(FourcatModule, BasicWorker, metaclass=abc.ABCMeta):
         standalone = self.dataset.copy(shallow=False)
         standalone.body_match = "(Filtered) " + top_parent.query
         standalone.datasource = top_parent.parameters.get("datasource", "custom")
-        
-        # Copy over annotations
+
         if top_parent.annotation_fields and top_parent.num_annotations() > 0:
-            
             # Get column names dynamically
             annotation_cols = self.db.fetchone("SELECT * FROM annotations LIMIT 1")
             annotation_cols = list(annotation_cols.keys())
             annotation_cols.remove("id")  # Set by the DB
             cols_str = ",".join(annotation_cols)
-            select_str = ",".join(["a."+col for col in annotation_cols if col != "dataset"])
-            
-            self.db.execute(f"INSERT INTO annotations ({cols_str}) "
-                            f"OVERRIDING USER VALUE "
-                            f"SELECT '{standalone.key}', {select_str} "
-                            f"FROM annotations AS a WHERE a.dataset = '{top_parent.key}' ")
-    
-        # Copy over annotation fields and update annotations with new IDs
+
+            cols_list = ["a." + col for col in annotation_cols if col != "dataset"]
+            query = f"INSERT INTO annotations ({cols_str}) OVERRIDING USER VALUE " \
+                    f"SELECT %s, {', '.join(cols_list)} " \
+                    f"FROM annotations AS a WHERE a.dataset = %s"
+
+            # Copy over all annotations if no item_ids are given
+            if not item_ids or top_parent.num_rows == standalone.num_rows:
+                self.db.execute(query, replacements=(standalone.key, top_parent.key))
+            else:
+                query += " AND a.item_id = ANY(%s)"
+                self.db.execute(query, replacements=(standalone.key, top_parent.key, item_ids))
+
+        # Copy over annotation fields and update annotations with new field IDs
         if top_parent.annotation_fields:
             # New field IDs based on the new dataset key
             annotation_fields = {
                 hash_to_md5(old_field_id + standalone.key): field_values
                 for old_field_id, field_values in top_parent.annotation_fields.items()
             }
-            standalone.annotation_fields = {}  # So we're not checking changes with old annotation fields
+            standalone.annotation_fields = {}  # Reset to insert everything without checking for changes
             standalone.save_annotation_fields(annotation_fields)  # Save to db
 
             # Also update field IDs in annotations

--- a/helper-scripts/export_4chan.py
+++ b/helper-scripts/export_4chan.py
@@ -62,7 +62,7 @@ else:
 	sys.exit(1)
 
 # Headers for csv writing
-headers =  ("num","resto","board","sub","com","time","time_utc","name","deleted","deleted_on","replies_to","id","capcode","tripcode","filename","tim","md5","w","h","tw","th","fsize","country","country_name","op","replies","images","semantic_url","sticky","closed","archived_on","scraped_on","modified_on","unique_ips","bumplimit","imagelimit","index_positions","unsorted_data")
+headers = ("num","resto","board","sub","com","time","time_utc","name","deleted","deleted_on","replies_to","id","capcode","tripcode","filename","tim","md5","w","h","tw","th","fsize","country","country_name","op","replies","images","semantic_url","sticky","closed","archived_on","scraped_on","modified_on","unique_ips","bumplimit","imagelimit","index_positions","unsorted_data")
 
 # Check board validity
 if args.board:

--- a/processors/filtering/column_filter.py
+++ b/processors/filtering/column_filter.py
@@ -223,7 +223,7 @@ class ColumnFilter(BaseFilter):
                     pass
 
             if matches:
-                yield mapped_item.original
+                yield mapped_item
                 matching_items += 1
 
     def filter_top(self, column, top_n, bottom=False):

--- a/processors/filtering/date_filter.py
+++ b/processors/filtering/date_filter.py
@@ -145,7 +145,7 @@ class DateFilter(BaseFilter):
 
             # Must be a good date!
             matching_items += 1
-            yield mapped_item.original
+            yield mapped_item
         
         if matching_items == 0:
             self.dataset.update_status("No items matched your criteria (%i invalid dates)" % invalid_dates, is_final=True)

--- a/processors/filtering/lexical_filter.py
+++ b/processors/filtering/lexical_filter.py
@@ -167,8 +167,8 @@ class LexicalFilter(BaseFilter):
                 continue
 
             # if one does, record which match, and save it to the output
-            # TODO: this is a conversion and will not show via map_items() for NDJSONs
+            # TODO: this is a conversion and will not show via map_items() for NDJSONs. Change to annotation!
             mapped_item.original["4cat_matching_lexicons"] = ",".join(matching_lexicons)
 
             matching_items += 1
-            yield mapped_item.original
+            yield mapped_item

--- a/processors/filtering/random_filter.py
+++ b/processors/filtering/random_filter.py
@@ -91,7 +91,7 @@ class RandomFilter(BaseFilter):
 				if count != (dataset_size - 1) and written < sample_size:
 					match_row = posts_to_keep[written]
 
-				yield mapped_item.original
+				yield mapped_item
 
 				if written % max(int(sample_size/10), 1) == 0:
 					self.dataset.update_status("Wrote %i posts" % written)

--- a/processors/filtering/unique_filter.py
+++ b/processors/filtering/unique_filter.py
@@ -115,7 +115,7 @@ class UniqueFilter(BaseFilter):
 
             if unique_item:
                 unique += 1
-                yield mapped_item.original
+                yield mapped_item
 
             if processed % 500 == 0:
                 self.dataset.update_status("Processed %i posts (%i unique)" % (processed, unique))

--- a/processors/filtering/wildcard_filter.py
+++ b/processors/filtering/wildcard_filter.py
@@ -77,4 +77,4 @@ class WildcardFilter(BaseFilter):
                 continue
 
             matching_items += 1
-            yield mapped_item.original
+            yield mapped_item


### PR DESCRIPTION
This ensures not all annotations are copied over when filtering, only those that are valid.

This works and makes sure things are not broken. It does raise several questions:

- For efficiency, we copied over annotations in `create_standalone()`. However this obviously does not work here because you don't want *all* annotations to be copied over. To 'filter' the copy, you need to know what posts passed the filter, but this info is not easily accessible.
  - To solve this I implemented an `item_ids` parameter in `create_standalone()` that indicates what items were actually filtered. These `item_ids` are tracked in `BaseFilter` and then passed to `create_standalone()` in `after_process()`.
  -  To get the ID per item I had to change the yielding of `mapped_item.original` in filter processors to `mapped_item`. `mapped_item.original` is then used in `BaseFilter`, which seems cleaner to me anyway.
  - This causes more memory use since the list of `item_ids` can be in the millions--but probably a matter of tens or hundreds of MBs, so not a huge issue.
- An alternative is to save annotations in the `BaseFilter` `iterate_items()`, but this adds a lot of overhead; copying is much faster.
- In the interface, a filtered dataset is now shown 'Filtered' without a link to the new dataset, and only as 'New dataset' when you refresh. Is this because of `after_process()` still running?


All of this is making me inch closer to @dale-wahl 's database campaign...