### PR TITLE
Security: SQL Injection via String Formatting in Migration Scripts

### DIFF
--- a/helper-scripts/migrate/migrate-1.12-1.13.py
+++ b/helper-scripts/migrate/migrate-1.12-1.13.py
@@ -1,4 +1,5 @@
 # this should have been done in the 1.9 -> 1.10 migration script, but alas...
+import re
 import sys
 import os
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), "../.."))
@@ -17,6 +18,10 @@ except (SyntaxError, ImportError, AttributeError):
 
 for datasource in ("8kun", "8chan"):
 	print("  Checking for %s database tables... " % datasource, end="")
+
+	if not re.match(r'^[a-zA-Z0-9_]+$', datasource):
+		print("invalid datasource name, skipping!")
+		continue
 
 	chan_table = db.fetchone("SELECT EXISTS ( SELECT FROM information_schema.tables WHERE table_schema = %s AND table_name = %s )", ("public", "posts_%s" % datasource))
 	if not chan_table["exists"]:


### PR DESCRIPTION
## Summary

Security: SQL Injection via String Formatting in Migration Scripts

## Problem

**Severity**: `High` | **File**: `helper-scripts/migrate/migrate-1.12-1.13.py:L33`

Multiple migration scripts construct SQL queries using Python string formatting with `%` or `.format()`, directly interpolating table names and column names. While some use parameterized queries for values, the table/column names are concatenated directly into the SQL string. This pattern appears across multiple migration files where datasource names are interpolated into table names like `posts_%s` and `threads_%s`. An attacker with control over datasource configuration could potentially inject malicious SQL through crafted datasource names.

## Solution

Use a whitelist of valid datasource names before interpolating into SQL, or use proper ORM methods. If dynamic table names are required, validate against known safe patterns using regex like `^[a-z0-9_]+$`.

## Changes

- `helper-scripts/migrate/migrate-1.12-1.13.py` (modified)