### PR TITLE
Processor catalogue & Output class

### DIFF
--- a/backend/lib/search.py
+++ b/backend/lib/search.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from backend.lib.processor import BasicProcessor
 from common.lib.helpers import strip_tags, dict_search_and_update, remove_nuls, HashCache, format_import_item
 from common.lib.exceptions import WorkerInterruptedException, ProcessorInterruptedException, MapItemException
+from common.lib.outputs import Datasource
 
 
 class Search(BasicProcessor, ABC):
@@ -31,6 +32,12 @@ class Search(BasicProcessor, ABC):
 	#: Search worker identifier - should end with 'search' for
 	#: backwards-compatibility reasons. For example, `instagram-search`.
 	type = "abstract-search"
+
+	#: Default output shape: a collected, top-level dataset whose extension is this
+	#: worker's own (ndjson for most, csv/zip for some). A data source that produces
+	#: media (an uploaded archive) or whose shape is only known at run time overrides
+	#: this with a MediaArchive or a per-worker Output.
+	output = Datasource()
 
 	# generic icon
 	icon = "comments"

--- a/common/lib/compatibility.py
+++ b/common/lib/compatibility.py
@@ -1,75 +1,71 @@
 """
 Declarative processor compatibility.
 
-A Compatibility object describes the conditions under which a processor can run
-on a dataset:
+A processor says what it accepts as a `Compatibility` -- the dataset type, file
+extension, media type, datasource, columns it needs, and the settings/executables its
+environment needs. `Compatibility.check(subject)` compares that against a `subject`,
+which is one of two things:
 
-* the data shape it consumes -- the dataset's type, file extension, media type,
-  datasource, and any columns it needs;
-* the environment it needs -- external executables and 4CAT configuration
-  settings;
-* the follow-up processors that are most relevant for its output, and any that
-  should never be offered.
+* a live dataset (wrapped in `DatasetShape`), when 4CAT decides at run time whether a
+  processor can run on a dataset;
+* a processor's declared output (a `Shape`, built in outputs.py from its `Output`),
+  when the processor map works out which processors can follow which without running
+  anything.
 
-A processor declares one as its `compatibility` class attribute, for example::
+Both answer the same handful of questions -- extension, media, columns, and so on --
+each a real value or `UNKNOWN` when a declared output has not pinned it down. `check`
+returns "yes", "no" or "maybe": a live dataset knows all its values so the answer is
+only ever yes/no, but a declared output can leave things open, which is where "maybe"
+comes from. There is one comparison, written once, so the run-time check and the map
+can never disagree.
 
-    compatibility = Compatibility(
-        media_types={"video"},
-        type_prefixes={"video-downloader"},
-        required_settings={("video-downloader.ffmpeg_path", is_executable)},
-    )
-
-BasicProcessor.is_compatible_with() evaluates it. A processor whose
-requirements cannot be expressed this way -- for example one that must inspect
-a dataset's ancestry -- may override is_compatible_with() instead; the override
-is used in preference to the attribute.
-
-`_maybe_call`: a utility function to safely read attributes or call methods on a
- module, handling cases where the attribute or method might not exist or raise an exception.
-Normally a `module` is a DataSet, but the values read here (its type, extension, media type
-and so on) are also available on a processor class, so a processor can be checked even when 
-no dataset exists yet.
+A processor whose acceptance can't be expressed this way (e.g. it must walk a dataset's
+ancestry) keeps a custom `is_compatible_with` method instead; that wins at run time.
 """
 from __future__ import annotations
 
 import shutil
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from functools import cached_property
+from typing import Iterable, Optional
 
 
-def _maybe_call(module, method, **kwargs):
+# Marks a property a declared output has not pinned down (a filter's extension, a deep
+# child's datasource, ...). It is *only* ever produced by a declared output -- a live
+# dataset always has a concrete value -- so it is what turns a "no" into a "maybe".
+UNKNOWN = object()
+
+# The columns that make a CSV rankable; three of them must be present (see get_columns
+# / is_rankable on DataSet). Rankability is worked out from the columns and extension a
+# subject has, so it never needs declaring separately.
+_RANK_COLUMNS = {"date", "value", "item"}
+
+
+def _maybe_call(subject, method, **kwargs):
     """
-    Read `module.method` without assuming it exists.
-
-    Calls it and returns the result when it is a method, returns the value when
-    it is a plain attribute, and returns None when it is missing or raises. A
-    DataSet exposes these as methods; a processor class exposes some of them as
-    well, and this keeps the same check working for both. Any keyword arguments
-    are forwarded to the call (e.g. is_rankable(multiple_items=False)).
+    Read `subject.method` without assuming it exists: call it when it is a method,
+    return it when it is a plain attribute, and return None when it is missing or
+    raises. A DataSet exposes these as methods, so this keeps DatasetShape simple.
     """
-    attr = getattr(module, method, None)
+    attr = getattr(subject, method, None)
     if attr is None:
         return None
     if callable(attr):
         try:
             return attr(**kwargs)
         except Exception:
-            # deliberately swallowed: a failing get_columns()/is_rankable() reads
-            # as "cannot determine"; could pass logger here to debug in case there is
-            # a real bug, but this caller is expected to handle None as "not met"
+            # a failing get_columns()/get_extension() reads as "no value", never a crash
             return None
     return attr
 
 
-# TODO: memoize shutil.which() (used by is_executable / ExecutableSibling) -- its
-# result is constant per process, so a cached wrapper (positive results only, to
-# avoid stale negatives if an executable is installed without a restart) would
-# avoid repeated $PATH scans on video-heavy pages.
+# TODO: memoize shutil.which() (used by is_executable / ExecutableSibling) -- its result
+# is constant per process, so a cached wrapper (positive results only) would avoid
+# repeated $PATH scans on video-heavy pages.
 def is_executable(path):
     """
-    Matcher for `required_settings`: the setting's value must point to an
-    executable found on the system (resolved with `shutil.which`). An unset or
-    empty value fails safely, e.g.::
+    Matcher for `required_settings`: the setting's value must point to an executable
+    found on the system (resolved with `shutil.which`). An unset value fails safely::
 
         required_settings={("video-downloader.ffmpeg_path", is_executable)}
     """
@@ -78,16 +74,12 @@ def is_executable(path):
 
 class ExecutableSibling:
     """
-    Matcher for `required_settings`: the configured executable must resolve (via
-    `shutil.which`) AND a sibling executable must exist next to it, found by
-    swapping the name in the resolved path. For tools that ship together, e.g.
-    ffprobe alongside ffmpeg::
+    Matcher for `required_settings`: the configured executable must resolve AND a sibling
+    executable must exist next to it, found by swapping the name in the resolved path.
+    For tools that ship together, e.g. ffprobe alongside ffmpeg::
 
         required_settings={("video-downloader.ffmpeg_path",
                              ExecutableSibling("ffmpeg", "ffprobe"))}
-
-    The matcher protocol is a one-argument callable, so arguments are passed via
-    the constructor; `name`/`sibling` stay readable for a future UI. None-safe.
     """
 
     def __init__(self, name, sibling):
@@ -98,9 +90,8 @@ class ExecutableSibling:
         resolved = shutil.which(path) if path else None
         if not resolved:
             return False
-        # if `name` is not in the resolved path, the rsplit/join below leaves it
-        # unchanged and we would re-check the same executable -- a false positive
-        # that never actually locates the sibling. Fail instead.
+        # if `name` is not in the resolved path the swap below is a no-op and we would
+        # re-check the same executable -- a false positive that never finds the sibling
         if self.name not in resolved:
             return False
         return shutil.which(self.sibling.join(resolved.rsplit(self.name, 1))) is not None
@@ -111,16 +102,13 @@ class Compatibility:
     """
     Declarative compatibility specification for a processor.
 
-    Any axis left unset (None, or empty) is not checked.
-
-    The four identity axes -- types, type_prefixes, media_types and
-    datasources -- describe what kind of dataset the processor accepts. If any
-    of them are set, the module must match at least one (they are OR-ed).
-    Every other axis is an additional requirement that must also hold (they are
-    AND-ed).
+    Any axis left unset (None, or empty) is not checked. The four identity axes --
+    types, type_prefixes, media_types and datasources -- describe what kind of input the
+    processor accepts; if any are set, the subject must match at least one (they are
+    OR-ed). Every other axis is an additional requirement that must also hold (AND-ed).
     """
 
-    # --- Identity axes: consumed data shape (the module must match one of these) ---
+    # --- Identity axes: what kind of input (match at least one of these) ---
     # Dataset types the processor accepts, matched exactly.
     types: Optional[Iterable[str]] = None
     # Dataset type prefixes the processor accepts, matched with str.startswith.
@@ -129,233 +117,412 @@ class Compatibility:
     media_types: Optional[Iterable[str]] = None
     # Datasources the processor accepts, e.g. {"4chan", "reddit"}.
     datasources: Optional[Iterable[str]] = None
-    # Collectors types (a dataset whose type ends in -search or -import) 
-    # Compare with top_dataset_only, which reads key_parent; the two cover nearly 
-    # the same datasets but differ in role (identity/OR vs gate/AND)
+    # Accepts a collector's output (a dataset whose type ends in -search or -import).
     is_collector: bool = False
 
-    # --- Shape gates (structural checks) ---
-     # Parent dataset types this processor CANNOT run on -- a hard gate
-    # (is_compatible_with returns False). Use when the processor would fail or
-    # produce garbage on that type (e.g. download_videos on telegram-search).
-    # For a soft filter use excluded_followups on the producer instead.
+    # --- Gates: extra conditions that must all hold ---
+    # Dataset types this processor CANNOT run on -- a hard veto. Use when it would fail
+    # or produce garbage on that type (e.g. download_videos on telegram-search). For a
+    # soft "don't suggest" use excluded_followups on the producer instead.
     excluded_types: Iterable[str] = ()
-
-    # --- DataSet required gates ---
-    # The ground truth requires an existing DataSet to read its produced data
-    # TODO: processors could declare these attributes more explicitly
-    # When True, the processor only accepts a top-level dataset (one with no parent).
+    # Accepts only a top-level dataset (no parent) / only a non-top-level (child) one.
     top_dataset_only: bool = False
-    # When True, the processor only accepts a non-top-level (child) dataset -- the
-    # inverse of top_dataset_only.
     child_only: bool = False
     # Result-file extensions the processor accepts, e.g. {"csv", "ndjson"}.
     extensions: Optional[Iterable[str]] = None
 
-    # --- Result file gates (reading the actual file is required)
-    # TODO: processors again could point to these attributes more explicitly if known
-    # dataset and cannot be resolved from a processor class -- see requires_dataset) ---
-    # When set, is_rankable() must equal this (read from the result file). None = not checked.
+    # --- Column/rankability gates (read from the produced data) ---
+    # When set, the subject's rankability must equal this. Worked out from its columns
+    # and extension (a CSV with date/value/item), so it is never declared directly.
     rankable: Optional[bool] = None
-    # Forwarded to is_rankable(multiple_items=...) when `rankable` is set. False
-    # restricts to single-value rankings (rejecting multi-column word_1/word_2/... rankings).
+    # Forwarded to the rank check: False rejects multi-value word_1/word_2/... rankings.
     rankable_multiple_items: bool = True
-    # Columns that must ALL be present in the dataset, read from its columns.
+    # Columns that must ALL be present / of which AT LEAST ONE must be present.
     requires_all_columns: Iterable[str] = ()
-    # Columns of which AT LEAST ONE must be present, read from its columns.
     requires_any_columns: Iterable[str] = ()
 
-    # --- Environment requirements ---
-    # Executables that must be found on the system path (checked with shutil.which).
+    # --- Environment requirements (about the machine, not the dataset) ---
+    # Executables that must be on the system path (checked with shutil.which).
     required_packages: Iterable[str] = ()
-    # Configuration the processor needs. Each entry is either a setting key,
-    # which must resolve to a truthy value, or a (key, expected) pair. The
-    # expected part may be a single value the setting must equal, a collection
-    # the setting's value must be in, or a function that receives the value and
-    # returns whether it is acceptable.
+    # Configuration the processor needs. Each entry is a setting key (which must be
+    # truthy) or a (key, expected) pair; `expected` may be a value the setting must
+    # equal, a collection it must be in, or a function that validates it.
     required_settings: Iterable = ()
 
-    # --- Follow-up processors ---
+    # --- Follow-up hints (not a requirement -- they describe this processor's output) ---
     # Processor types to recommend first as next steps for this processor's output.
     preferred_followups: Iterable[str] = ()
-    # Processor types never SUGGESTED as follow-ups after this one -- a soft
-    # filter (affects the suggestion list only; is_compatible_with is unchanged,
-    # so they can still be run directly). Use for "a more specific processor is
-    # preferred here" (e.g. tiktok-search excludes the generic video-downloader).
-    # For "that processor would fail on this output", use its excluded_types (hard).
+    # Processor types never suggested after this one (a soft filter; they can still be
+    # run directly). For "would fail on this output" use that processor's excluded_types.
     excluded_followups: Iterable[str] = ()
+
+    # -- the one comparison --
+
+    def check(self, subject) -> str:
+        """
+        Compare `subject` against this spec, returning "yes", "no" or "maybe".
+
+        `subject` is a live dataset (DatasetShape) or a declared output (Shape); both
+        answer the same questions, a real value or UNKNOWN when an output has not said.
+        "no" means a condition is definitely unmet; "maybe" means everything known
+        passes but the output left something we check undefined; "yes" means all met. A
+        live dataset knows all its values, so for a dataset the answer is only yes/no.
+
+        Only the data shape is compared here; the environment is environment_ok().
+        """
+        maybe = False
+
+        # identity -- if we name any kind of input, the subject must be one of them
+        if self._accepts_a_kind():
+            kind = self._kind_result(subject)
+            if kind == "no":
+                return "no"
+            if kind == "maybe":
+                maybe = True
+
+        # a type we refuse outright
+        if subject.type in set(self.excluded_types):
+            return "no"
+
+        # structural position
+        if self.top_dataset_only:
+            if subject.top_level is UNKNOWN:
+                maybe = True
+            elif not subject.top_level:
+                return "no"
+        if self.child_only:
+            if subject.top_level is UNKNOWN:
+                maybe = True
+            elif subject.top_level:
+                return "no"
+
+        # file extension
+        if self.extensions:
+            if subject.extension is UNKNOWN:
+                maybe = True
+            elif subject.extension not in set(self.extensions):
+                return "no"
+
+        # columns the processor needs to read
+        if self.requires_all_columns or self.requires_any_columns:
+            columns = self._columns_result(subject)
+            if columns == "no":
+                return "no"
+            if columns == "maybe":
+                maybe = True
+
+        # rankable (a CSV with date/value/item columns)
+        if self.rankable is not None:
+            rankable = _is_rankable(subject, self.rankable_multiple_items)
+            if rankable is UNKNOWN:
+                maybe = True
+            elif rankable != self.rankable:
+                return "no"
+
+        return "maybe" if maybe else "yes"
+
+    def is_compatible_with(self, module, config=None) -> bool:
+        """
+        Whether a real dataset can be run on. A live dataset knows all its values, so
+        check() is only ever "yes"/"no" here. `module` is normally a DataSet.
+        """
+        return self.check(DatasetShape(module)) == "yes" and self.environment_ok(config)
+
+    def environment_ok(self, config=None) -> bool:
+        """
+        Whether the system has the settings and executables the processor needs. This is
+        about the machine, not the dataset, so the map surfaces it as a note on the
+        processor rather than removing a connection.
+        """
+        for requirement in self.required_settings:
+            key, expected = (requirement, None) if isinstance(requirement, str) else requirement
+            value = config.get(key) if config is not None else None
+            if expected is None:
+                met = bool(value)
+            elif callable(expected):
+                met = bool(expected(value))
+            elif isinstance(expected, (set, frozenset, list, tuple)):
+                met = value in expected
+            else:
+                met = value == expected
+            if not met:
+                return False
+        for package in self.required_packages:
+            if not shutil.which(package):
+                return False
+        return True
 
     @property
     def requires_dataset_result_file(self) -> bool:
         """
-        Whether fully evaluating this spec needs the dataset's produced data.
-
-        True when `rankable`, `requires_all_columns`, or `requires_any_columns` is
-        set: all are read from the produced result file, so they cannot be
-        resolved from a processor class alone. (Shape axes such as
-        top_dataset/extension also read instance state, but they are recoverable
-        from a dataset's shape; only these need the produced data, so only they
-        are counted here.) A consumer that reasons about processors without real
-        datasets (e.g. a processor map) can use this to mark those axes as
-        undecided rather than treating them as failed.
+        Whether fully deciding this spec needs the produced data -- true when it gates on
+        rankability or columns, both read from the result file. The map exposes this so
+        the UI can say "you'll only know for certain once it runs".
         """
         return (self.rankable is not None
                 or bool(self.requires_all_columns)
                 or bool(self.requires_any_columns))
 
-    def is_compatible_with(self, module, config=None) -> bool:
-        """
-        Return whether `module` meets every requirement in this specification.
+    # -- helpers for check(); each returns "yes"/"no"/"maybe" --
 
-        `module` is normally a DataSet but may be a processor class. `config`
-        is the configuration reader, or None when none is available.
-        """
-        return not self.unmet_requirements(module, config=config)
+    def _accepts_a_kind(self) -> bool:
+        """Whether the spec names any kind of input it accepts."""
+        return self.is_collector or any(axis is not None for axis in
+                                        (self.types, self.type_prefixes, self.media_types, self.datasources))
 
-    def unmet_requirements(self, module, config=None, first_only=True) -> List[str]:
-        """
-        Return the requirements `module` does not meet, as readable strings.
+    def _kind_result(self, subject) -> str:
+        """Identity is OR: "yes" if the subject is any kind we accept, "no" only if it is
+        definitely none, else "maybe"."""
+        maybe = False
+        for outcome in self._kind_checks(subject):
+            if outcome == "yes":
+                return "yes"
+            if outcome == "maybe":
+                maybe = True
+        return "maybe" if maybe else "no"
 
-        An empty list means `module` is compatible. Each string names one thing
-        that is missing -- a wrong dataset type, an absent column, a setting
-        that is not configured, and so on.
-
-        The checks run in three tiers, cheapest first so the short-circuit can
-        skip later work once something fails:
-
-        1. structural -- the dataset's shape (type, extension, parent,
-           datasource); cheap, no result-file read. (Several still read instance
-           state -- is_top_dataset() -> key_parent, get_extension(), parameters --
-           so on a bare processor class they return a stub, not a real answer.)
-        2. dataset-required -- `rankable`, `requires_all_columns`, and
-           `requires_any_columns`, read from the produced result file, so they
-           need a materialized DataSet (see `requires_dataset_result_file`);
-        3. environment -- configuration settings and system executables.
-
-        By default the method returns as soon as one requirement is unmet --
-        enough for the yes/no `is_compatible_with`. Pass `first_only=False` to
-        collect every unmet requirement -- used to explain why a module is not
-        compatible.
-        """
-        reasons: List[str] = []
-        if module is None:
-            return ["no dataset provided"]
-
-        # --- tier 1: structural shape (cheap; no result-file read) ---
-
-        # if the processor names the kinds of dataset it accepts, the module
-        # must be one of them
-        if self._identity_declared() and not self._identity_matches(module):
-            reasons.append("dataset type/media is not accepted")
-            if first_only:
-                return reasons
-
-        if self.excluded_types and getattr(module, "type", None) in set(self.excluded_types):
-            reasons.append("does not run on dataset type: %s" % getattr(module, "type", None))
-            if first_only:
-                return reasons
-
-        if self.top_dataset_only and not _maybe_call(module, "is_top_dataset"):
-            reasons.append("requires a top-level dataset")
-            if first_only:
-                return reasons
-
-        if self.child_only and _maybe_call(module, "is_top_dataset"):
-            reasons.append("requires a child (non-top-level) dataset")
-            if first_only:
-                return reasons
-
-        if self.extensions is not None:
-            extension = _maybe_call(module, "get_extension")
-            if extension not in set(self.extensions):
-                reasons.append("requires extension: %s" % ", ".join(self.extensions))
-                if first_only:
-                    return reasons
-
-        # --- tier 2: dataset-required (read from the result file; cannot be
-        # resolved from a processor class -- see requires_dataset_result_file) ---
-
-        if self.rankable is not None:
-            if bool(_maybe_call(module, "is_rankable", multiple_items=self.rankable_multiple_items)) != self.rankable:
-                reasons.append(
-                    "requires a rankable dataset" if self.rankable
-                    else "requires a non-rankable dataset"
-                )
-                if first_only:
-                    return reasons
-
-        if self.requires_all_columns or self.requires_any_columns:
-            columns = _maybe_call(module, "get_columns") or []
-            missing = [column for column in self.requires_all_columns if column not in columns]
-            if missing:
-                reasons.append("requires all column(s): %s" % ", ".join(missing))
-                if first_only:
-                    return reasons
-            if self.requires_any_columns and not any(column in columns for column in self.requires_any_columns):
-                reasons.append("requires any of column(s): %s" % ", ".join(self.requires_any_columns))
-                if first_only:
-                    return reasons
-
-        # --- tier 3: environment (needs config/system, not a DataSet; the
-        # executable matchers here can be expensive, so this tier runs last.
-        # TODO: cheap setting reads could be split out ahead of those matchers) ---
-        for requirement in self.required_settings:
-            key, expected = (requirement, None) if isinstance(requirement, str) else requirement
-            value = config.get(key) if config is not None else None
-            # no expected value; just check that the setting is truthy
-            if expected is None:
-                met = bool(value)
-            # a function that validates the value (e.g. is_executable / ExecutableSibling)
-            elif callable(expected):
-                met = bool(expected(value))
-            # a collection of acceptable values
-            elif isinstance(expected, (set, frozenset, list, tuple)):
-                met = value in expected
-            # a single expected value
-            else:
-                met = value == expected
-            if not met:
-                reasons.append("requires setting: %s" % key)
-                if first_only:
-                    return reasons
-
-        for package in self.required_packages:
-            if not shutil.which(package):
-                reasons.append("requires package: %s" % package)
-                if first_only:
-                    return reasons
-
-        return reasons
-
-    def _identity_declared(self) -> bool:
-        """Whether the processor names any kind of dataset it accepts."""
-        return self.is_collector or any(
-            axis is not None
-            for axis in (self.types, self.type_prefixes, self.media_types, self.datasources)
-        )
-
-    def _identity_matches(self, module) -> bool:
-        """Whether the module is one of the kinds of dataset the processor accepts."""
-        module_type = getattr(module, "type", None)
-
-        if self.types is not None and module_type in set(self.types):
-            return True
-
-        if self.type_prefixes is not None and module_type is not None \
-                and any(module_type.startswith(prefix) for prefix in self.type_prefixes):
-            return True
-
+    def _kind_checks(self, subject):
+        """One outcome per identity axis the spec declares, cheapest first."""
+        if self.types is not None:
+            yield "yes" if subject.type in set(self.types) else "no"
+        if self.type_prefixes is not None:
+            yield "yes" if (subject.type and subject.type.startswith(tuple(self.type_prefixes))) else "no"
         if self.media_types is not None:
-            media = _maybe_call(module, "get_media_type") or getattr(module, "media_type", None)
-            if media in set(self.media_types):
-                return True
-
+            yield _media_result(set(self.media_types), subject.media)
         if self.datasources is not None:
-            parameters = getattr(module, "parameters", None) or {}
-            if isinstance(parameters, dict) and parameters.get("datasource") in set(self.datasources):
-                return True
+            if subject.datasource is UNKNOWN:
+                yield "maybe"
+            else:
+                yield "yes" if subject.datasource in set(self.datasources) else "no"
+        if self.is_collector:
+            if subject.from_collector is UNKNOWN:
+                yield "maybe"
+            else:
+                yield "yes" if subject.from_collector else "no"
 
-        if self.is_collector and _maybe_call(module, "is_from_collector"):
+    def _columns_result(self, subject) -> str:
+        """Does the subject have the columns we need? A missing column is a definite "no"
+        only when we know its columns are the complete set (a real dataset, or an output
+        that has none); an output floor might still gain the column, so it is "maybe"."""
+        columns = subject.columns
+        if columns is UNKNOWN:
+            return "maybe"
+        complete = subject.columns_are_all
+        outcome = "yes"
+        if self.requires_all_columns and not set(self.requires_all_columns) <= columns:
+            if complete:
+                return "no"
+            outcome = "maybe"
+        if self.requires_any_columns and not (columns & set(self.requires_any_columns)):
+            if complete:
+                return "no"
+            outcome = "maybe"
+        return outcome
+
+
+def _media_result(accepted, media) -> str:
+    """Compare a set of accepted media against a subject's media, which may be one value,
+    a set of possible values (a media archive that could hold image OR video), or
+    UNKNOWN."""
+    if media is UNKNOWN:
+        return "maybe"
+    values = set(media) if isinstance(media, (set, frozenset)) else {media}
+    if values <= accepted:
+        return "yes"
+    if values & accepted:
+        return "maybe"
+    return "no"
+
+
+def _is_rankable(subject, multiple_items):
+    """Whether the subject is rankable: a CSV with at least three of the ranking columns.
+    UNKNOWN when the output has not pinned its extension or columns."""
+    ranking = _RANK_COLUMNS | ({"word_1"} if multiple_items else set())
+    extension, columns = subject.extension, subject.columns
+    if extension is UNKNOWN:
+        return UNKNOWN                    # can't tell whether it's a CSV
+    if extension != "csv":
+        return False                      # a known non-CSV is never rankable
+    if columns is UNKNOWN:
+        return UNKNOWN                     # a CSV, but its columns aren't declared
+    if len(columns & ranking) >= 3:
+        return True
+    return False if subject.columns_are_all else UNKNOWN
+
+
+class DatasetShape:
+    """
+    A live dataset, presented as the plain properties check() reads. Every value comes
+    from the dataset's own methods, so it is always concrete -- a real dataset is never
+    "maybe". Read lazily and cached, so the slower reads (columns) happen only for a spec
+    that actually needs them.
+    """
+
+    columns_are_all = True  # a real dataset's columns are all the columns it has
+
+    def __init__(self, dataset):
+        self._dataset = dataset
+
+    @property
+    def type(self):
+        return getattr(self._dataset, "type", None)
+
+    @cached_property
+    def extension(self):
+        return _maybe_call(self._dataset, "get_extension")
+
+    @cached_property
+    def media(self):
+        return _maybe_call(self._dataset, "get_media_type") or getattr(self._dataset, "media_type", None)
+
+    @cached_property
+    def datasource(self):
+        parameters = getattr(self._dataset, "parameters", None) or {}
+        return parameters.get("datasource") if isinstance(parameters, dict) else None
+
+    @cached_property
+    def top_level(self):
+        return bool(_maybe_call(self._dataset, "is_top_dataset"))
+
+    @cached_property
+    def from_collector(self):
+        return bool(_maybe_call(self._dataset, "is_from_collector"))
+
+    @cached_property
+    def columns(self):
+        columns = _maybe_call(self._dataset, "get_columns")
+        return frozenset(columns) if columns else frozenset()
+
+
+@dataclass(frozen=True)
+class Shape:
+    """
+    A processor's declared output, as the plain properties check() reads. A value is
+    UNKNOWN when the processor's Output leaves it open (a filter's extension, say).
+    `columns_are_all` is True only when the output has NO columns; a declared column set
+    is a floor (at least these), so it is False. Built from an Output in outputs.py, or
+    inferred from the class for a processor that declares none.
+    """
+
+    type: Optional[str]
+    extension: object = UNKNOWN       # a str, or UNKNOWN
+    media: object = UNKNOWN            # a str, a set of str, or UNKNOWN
+    datasource: object = UNKNOWN       # a str, or UNKNOWN
+    top_level: object = UNKNOWN        # a bool, or UNKNOWN
+    from_collector: object = UNKNOWN   # a bool, or UNKNOWN
+    columns: object = UNKNOWN          # a frozenset, or UNKNOWN
+    columns_are_all: bool = False
+    produces_file: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared with outputs.py (which builds a Shape and needs to know a processor's
+# collector-ness), and the spec serialiser the catalogue displays.
+# ---------------------------------------------------------------------------
+
+def _is_collector_type(type_id) -> bool:
+    """A collector/datasource output: its type ends in `-search` or `-import`."""
+    return bool(type_id) and (type_id.endswith("-search") or type_id.endswith("-import"))
+
+
+def _declared_class_value(processor, name):
+    """
+    The value of class attribute `name` if the processor (or a parent class below
+    BasicProcessor) actually sets it, otherwise None. This tells a real choice apart from
+    a value merely inherited from BasicProcessor (the `extension = "csv"` default every
+    processor gets for free). A shared parent such as Search or a base filter counts as a
+    real choice; BasicProcessor itself, and anything above it, does not.
+    """
+    cls = processor if isinstance(processor, type) else type(processor)
+    try:
+        from backend.lib.processor import BasicProcessor
+    except Exception:
+        BasicProcessor = None
+    for klass in cls.__mro__:
+        if klass is object or klass is BasicProcessor or klass.__name__ == "BasicProcessor":
+            break
+        if name in vars(klass):
+            return vars(klass)[name]
+    return None
+
+
+def is_collector(processor) -> bool:
+    """
+    Whether a processor starts a chain -- a Search subclass, or (fallback) a
+    -search/-import type. This is about its role as a starting point, separate from
+    whether its *output* counts as a collector's (a filter's result can be made to look
+    like one, so that is left unknown for a filter).
+    """
+    try:
+        from backend.lib.search import Search
+        if isinstance(processor, type) and issubclass(processor, Search):
             return True
+    except Exception:
+        pass
+    return _is_collector_type(getattr(processor, "type", None))
 
-        return False
+
+def is_declaratively_compatible(processor) -> bool:
+    """
+    Whether the processor relies solely on its declared `compatibility` -- i.e. it does
+    NOT keep a custom `is_compatible_with`. When False it escapes into runtime logic the
+    specs can't see, so a map built from specs alone can only approximate edges into it.
+    """
+    try:
+        from backend.lib.processor import BasicProcessor
+    except Exception:
+        return True
+    own = getattr(getattr(processor, "is_compatible_with", None), "__func__", None)
+    base = getattr(BasicProcessor.is_compatible_with, "__func__", None)
+    has_override = own is not None and base is not None and own is not base
+    return not has_override
+
+
+def describe_spec(spec) -> Optional[dict]:
+    """
+    Serialise a Compatibility to a dict of only its *declared* axes, for display and as
+    the "requirement" label in the map. Defaults and empties are omitted, so what shows
+    is exactly what the processor opted into. Returns None for an undeclared spec.
+
+    (test_describe_spec_covers_every_compatibility_axis asserts every axis appears here.)
+    """
+    if spec is None:
+        return None
+
+    def norm(value):
+        if isinstance(value, (set, frozenset)):
+            return sorted(value)
+        if isinstance(value, (list, tuple)):
+            return list(value)
+        return value
+
+    declared = {}
+    for axis in ("types", "type_prefixes", "media_types", "datasources"):
+        value = getattr(spec, axis, None)
+        if value:
+            declared[axis] = norm(value)
+    if getattr(spec, "is_collector", False):
+        declared["is_collector"] = True
+    if getattr(spec, "extensions", None):
+        declared["extensions"] = norm(spec.extensions)
+    for gate in ("top_dataset_only", "child_only"):
+        if getattr(spec, gate, False):
+            declared[gate] = True
+    if getattr(spec, "excluded_types", None):
+        declared["excluded_types"] = norm(spec.excluded_types)
+    if getattr(spec, "rankable", None) is not None:
+        declared["rankable"] = spec.rankable
+    if getattr(spec, "requires_all_columns", None):
+        declared["requires_all_columns"] = norm(spec.requires_all_columns)
+    if getattr(spec, "requires_any_columns", None):
+        declared["requires_any_columns"] = norm(spec.requires_any_columns)
+    if getattr(spec, "required_settings", None):
+        keys = [r if isinstance(r, str) else r[0] for r in spec.required_settings]
+        declared["required_settings"] = sorted(keys)
+    if getattr(spec, "required_packages", None):
+        declared["required_packages"] = norm(spec.required_packages)
+    for followup in ("preferred_followups", "excluded_followups"):
+        value = getattr(spec, followup, None)
+        if value:
+            declared[followup] = norm(value)
+    return declared

--- a/common/lib/dataset.py
+++ b/common/lib/dataset.py
@@ -2378,6 +2378,28 @@ class DataSet(FourcatModule):
         # Default to text
         return self.parameters.get("media_type", "text")
 
+    def set_media_type(self, media_type):
+        """
+        Set the media type of this dataset's file.
+
+        For processors whose output media is only known while running (for example,
+        from the type of an uploaded file). The processor's declared `output` states
+        the media it can produce; this pins the one it actually produced. Stored on
+        the instance for the current run and in the parameters so later reads (after
+        a reload) return it too.
+
+        :param str media_type:  Media type, e.g. "image"
+        :return str:  The media type that was set
+        """
+        self.media_type = media_type
+        self.parameters["media_type"] = media_type
+        self.db.update(
+            "datasets",
+            data={"parameters": json.dumps(self.parameters)},
+            where={"key": self.key},
+        )
+        return media_type
+
     def get_media_from_children(self, item_ids=[]) -> dict:
         """ Returns a list of media filenames that have been downloaded
             via video or image download child processors

--- a/common/lib/outputs.py
+++ b/common/lib/outputs.py
@@ -1,0 +1,273 @@
+"""
+What a processor produces.
+
+A processor states the shape of its output as an `output` class attribute -- an Output,
+usually one of the archetypes below. This is the counterpart to Compatibility (what a
+processor accepts): the two together let the processor map decide which processors can
+follow which, without running anything.
+
+Most processors never write one by hand -- the base classes set a sensible default (a
+data source produces an ndjson table, a filter passes its parent's shape through) and a
+processor overrides only the field that differs, e.g. `output = Table(columns={"date",
+"item", "value"})`. The archetypes:
+
+    Datasource    a collected, top-level table (its own extension, columns from its items)
+    Table         a derived table (csv/ndjson)
+    Filter        same shape as the parent (extension, media and columns pass through)
+    Network       a single graph file (gexf), no columns
+    Render        a single image (svg/png), no columns
+    MediaArchive  a zip of media files, no columns
+    Archive       a zip of data files, no columns
+    File          a single json/txt/html file, no columns
+    Delegated     a preset whose real output is its pipeline's last step (unknown here)
+    NoOutput      writes no result file (e.g. only adds annotations to its parent)
+
+`describe_output(processor)` turns the declaration into a Shape -- the plain properties
+Compatibility.check reads -- filling in UNKNOWN for anything left open. A processor that
+declares nothing falls back to inferring a Shape from its class.
+"""
+from __future__ import annotations
+
+from common.lib.compatibility import (
+    Shape,
+    UNKNOWN,
+    _is_collector_type,
+    is_collector,
+    _maybe_call,
+    _declared_class_value,
+)
+
+
+class _Sentinel:
+    def __init__(self, name):
+        self._name = name
+
+    def __repr__(self):
+        return self._name
+
+
+# Use for any field whose value is the parent dataset's (a filter's extension, media or
+# columns) -- unknown until the chain is known, so it only ever softens an answer.
+PASSTHROUGH = _Sentinel("PASSTHROUGH")
+# Use as an extension when the processor's own `extension` class attribute is the real,
+# trusted value (a data source whose subclasses each set their own).
+CLASS_EXTENSION = _Sentinel("CLASS_EXTENSION")
+# Use as `columns` when the output has no column table at all (a network, image, or media
+# archive). A consumer that needs a column then gets a definite "no".
+NO_COLUMNS = _Sentinel("NO_COLUMNS")
+
+
+def _extension_value(value, processor):
+    if value is PASSTHROUGH or value is None:
+        return UNKNOWN
+    if value is CLASS_EXTENSION:
+        return getattr(processor, "extension", None) or UNKNOWN
+    return value  # a plain extension string
+
+
+def _media_value(value):
+    if value is None or value is PASSTHROUGH:
+        return UNKNOWN
+    if isinstance(value, (set, frozenset, list, tuple)):
+        return set(value)  # a bounded set: could be image OR video OR ...
+    return value  # a single media string
+
+
+def _datasource_value(value, collector, ptype):
+    if value is not None and value is not PASSTHROUGH:
+        return value
+    # a collector carries its datasource in its type; anything else passes it through
+    if collector and _is_collector_type(ptype):
+        return ptype.rsplit("-", 1)[0]
+    return UNKNOWN
+
+
+def _top_level_value(position):
+    if position == "top":
+        return True
+    if position == "child":
+        return False
+    return UNKNOWN
+
+
+def _columns_value(value):
+    """Returns (columns, columns_are_all) the way Shape wants them."""
+    if value is None or value is PASSTHROUGH:
+        return UNKNOWN, False
+    if value is NO_COLUMNS:
+        return frozenset(), True  # definitely no columns
+    return frozenset(value), False  # a floor: at least these
+
+
+class Output:
+    """
+    The shape a processor produces. Subclass it for the common archetypes; the fields are
+    kept as plain values and turned into a Shape by to_shape. Any field left None is
+    "unknown" -- it can never cause a false "no", only soften an answer to "maybe".
+    `produces_file` is False for a processor that writes no result file.
+    """
+
+    def __init__(self, *, extension=None, media="text", columns=None,
+                 position="child", collector=False, datasource=None, produces_file=True):
+        self.extension = extension      # str | set | PASSTHROUGH | CLASS_EXTENSION | None
+        self.media = media              # str | set | PASSTHROUGH | None
+        self.columns = columns          # set | NO_COLUMNS | PASSTHROUGH | None
+        self.position = position        # "top" | "child" | None
+        self.collector = collector      # bool | None
+        self.datasource = datasource    # str | PASSTHROUGH | None
+        self.produces_file = produces_file
+
+    def to_shape(self, processor) -> Shape:
+        """Turn this into the Shape Compatibility.check reads. `processor` supplies the
+        type (and, for a collector, the datasource it carries)."""
+        ptype = getattr(processor, "type", None)
+        columns, columns_are_all = _columns_value(self.columns)
+        return Shape(
+            type=ptype,
+            extension=_extension_value(self.extension, processor),
+            media=_media_value(self.media),
+            datasource=_datasource_value(self.datasource, self.collector, ptype),
+            top_level=_top_level_value(self.position),
+            from_collector=UNKNOWN if self.collector is None else bool(self.collector),
+            columns=columns,
+            columns_are_all=columns_are_all,
+            produces_file=self.produces_file,
+        )
+
+
+# Default archetypes for the common processor types. A processor can override any field
+# by declaring its own Output (or subclass) as its `output` class attribute.
+
+class Datasource(Output):
+    """A collected, top-level dataset. Its extension is its own (ndjson for most, csv or
+    zip for some), trusted because it drives the result file. Defaults to text items;
+    pass `columns` to sharpen. A data source producing media uses MediaArchive."""
+
+    def __init__(self, *, extension=CLASS_EXTENSION, columns=None, media="text", datasource=None):
+        super().__init__(extension=extension, media=media, columns=columns,
+                         position="top", collector=True, datasource=datasource)
+
+
+class Table(Output):
+    """A derived table. Defaults to a csv of text; pass `columns` to sharpen."""
+
+    def __init__(self, *, columns=None, media="text", extension="csv"):
+        super().__init__(extension=extension, media=media, columns=columns,
+                         position="child", collector=False)
+
+
+class Filter(Output):
+    """A filter: extension, media and columns all follow the parent, and its position and
+    collector-ness are unknown (its result may be made standalone)."""
+
+    def __init__(self):
+        super().__init__(extension=PASSTHROUGH, media=PASSTHROUGH, columns=PASSTHROUGH,
+                         position=None, collector=None, datasource=PASSTHROUGH)
+
+
+class Network(Output):
+    """A single graph file (gexf) with no column table."""
+
+    def __init__(self, *, extension="gexf"):
+        super().__init__(extension=extension, media="text", columns=NO_COLUMNS,
+                         position="child", collector=False)
+
+
+class Render(Output):
+    """A single rendered image (svg by default, or png) with no column table."""
+
+    def __init__(self, extension="svg", *, media="image"):
+        super().__init__(extension=extension, media=media, columns=NO_COLUMNS,
+                         position="child", collector=False)
+
+
+class MediaArchive(Output):
+    """A zip archive of media files with no column table. `media` is the kind of media in
+    it (a single value, or a set when it varies per file)."""
+
+    def __init__(self, *, media=None, collector=False, position="child"):
+        if media is None:
+            media = {"image", "video", "audio", "file"}
+        super().__init__(extension="zip", media=media, columns=NO_COLUMNS,
+                         position=position, collector=collector)
+
+
+class Archive(Output):
+    """A zip archive of data files with no column table (tokens, embeddings, an export
+    bundle). For an archive of media files use MediaArchive."""
+
+    def __init__(self, *, media="text", collector=False, position="child"):
+        super().__init__(extension="zip", media=media, columns=NO_COLUMNS,
+                         position=position, collector=collector)
+
+
+class File(Output):
+    """A single non-tabular file (e.g. json, txt, html) with no column table."""
+
+    def __init__(self, extension, *, media="text"):
+        super().__init__(extension=extension, media=media, columns=NO_COLUMNS,
+                         position="child", collector=False)
+
+
+class Delegated(Output):
+    """A preset that writes no file of its own; its real output is whatever the last
+    processor in its pipeline produces, so the shape is unknown here. `terminal` names
+    that last processor when it is known."""
+
+    def __init__(self, terminal=None):
+        super().__init__(extension=PASSTHROUGH, media=None, columns=None,
+                         position=None, collector=False)
+        self.terminal = terminal
+
+
+class NoOutput(Output):
+    """Produces no result file (for example, only adds annotations to its parent), so
+    nothing can run on it."""
+
+    def __init__(self):
+        super().__init__(extension=None, media=None, columns=NO_COLUMNS,
+                         position=None, collector=False, produces_file=False)
+
+
+def _infer_output(processor) -> Shape:
+    """
+    Work out a processor's output from its class -- the fallback for a processor that
+    declares no `output` (today only third-party extensions). It synthesises a plain
+    Output from what the class safely promises and hands it to to_shape, so the
+    class-to-shape conversion lives in one place. A filter is passthrough; a collector is
+    top-level with its datasource; anything else is a child with its trusted class
+    extension (an inherited default stays unknown, never a false claim).
+    """
+    collector = is_collector(processor)
+    is_filter = bool(_maybe_call(processor, "is_filter"))
+    declared_media = _declared_class_value(processor, "media_type")
+
+    if collector:
+        position, collector_flag = "top", True
+    elif is_filter:
+        position, collector_flag = None, None
+    else:
+        position, collector_flag = "child", False
+
+    extension = PASSTHROUGH if is_filter else _declared_class_value(processor, "extension")
+
+    return Output(
+        extension=extension,
+        media=declared_media or None,
+        columns=None,
+        position=position,
+        collector=collector_flag,
+    ).to_shape(processor)
+
+
+def describe_output(processor) -> Shape:
+    """
+    A processor's output as a Shape Compatibility.check can read. Reads the processor's
+    declared `output` when it has one; otherwise falls back to inferring it from the
+    class. The single place that chooses between the two, so everything downstream reads
+    one kind of shape regardless.
+    """
+    declared = getattr(processor, "output", None)
+    if isinstance(declared, Output):
+        return declared.to_shape(processor)
+    return _infer_output(processor)

--- a/common/lib/processor_map.py
+++ b/common/lib/processor_map.py
@@ -264,33 +264,77 @@ class ProcessorMap:
             "from_processors": [self._step(p, self._edge.get((p, ptype))) for p in from_processors],
         }
 
-    def _starting_points(self, ptype):
+    def _confirmed_producers(self, ptype):
+        """Processors and data sources whose output `ptype` definitely accepts, filters
+        excluded (they are transparent -- see followups)."""
+        return [p for p in self._producers(ptype, "definite") if not self._filter[p]]
+
+    def _match_strength(self, consumer_type, producer_type):
         """
-        The sensible places to start: a data source you can run this on directly, or one
-        you can run it on after a single processor. The cap of one step is deliberate -- a
-        source only counts if it (or one processor run on it) directly produces something
-        this accepts. Longer routes usually exist, but reaching a processor through many
-        hops is seldom the sensible way in and would bury the obvious starts under every
-        distant path; those are found by opening the processors along the way. A source it
-        accepts directly has an empty `then` (run it straight away); otherwise `then` names
-        the one processor to run first. Filters are skipped (transparent).
+        How fully a producer's output matches what `consumer_type` says it accepts: the
+        number of "what kind of input" axes (type, type-prefix, media, datasource) the
+        producer definitely satisfies. Used only to order example paths, so a producer built
+        for the job (an image downloader for an image step) is preferred over one that
+        matches only incidentally (a chart that merely happens to be an image).
         """
-        routes = {}  # datasource -> [processor to run first]; [] means run it straight away
-        producers = self._producers(ptype, "definite")
-        # data sources this runs on directly
-        for producer in producers:
-            if self._collector[producer]:
-                routes[producer] = []
-        # data sources one step removed: source -> producer -> this, both links confirmed
-        for producer in producers:
-            if self._collector[producer] or self._filter[producer]:
-                continue
-            for source in self._producers(producer, "definite"):
-                if self._collector[source] and source not in routes:
-                    routes[source] = [producer]
-        return [{"datasource": source, "title": self._title(source),
-                 "then": [{"type": step, "title": self._title(step)} for step in then]}
-                for source, then in sorted(routes.items())]
+        spec = self._match_spec.get(consumer_type)
+        shape = self._shapes.get(producer_type)
+        if spec is None or shape is None:
+            return 0
+        strength = 0
+        if spec.types and shape.type in set(spec.types):
+            strength += 1
+        if spec.type_prefixes and shape.type and shape.type.startswith(tuple(spec.type_prefixes)):
+            strength += 1
+        if spec.media_types and shape.media is not UNKNOWN:
+            have = shape.media if isinstance(shape.media, (set, frozenset)) else {shape.media}
+            if have and have <= set(spec.media_types):
+                strength += 1
+        if spec.datasources and shape.datasource is not UNKNOWN and shape.datasource in set(spec.datasources):
+            strength += 1
+        return strength
+
+    def _examples(self, ptype, count=3):
+        """
+        A few concrete example paths from a data source to `ptype` -- illustrations of how
+        you might reach it, NOT a complete or curated list. Each example is a full chain (a
+        data source, the processors to run in order, then `ptype`) and shows a different
+        thing to run `ptype` on: one example per direct producer, via the shortest way to
+        reach that producer. Producers are ordered by how fully they match `ptype`'s stated
+        input (see _match_strength), so a processor built for the job leads and a merely
+        incidental match (a chart that happens to be an image, for an image step) shows only
+        if nothing better exists. One-per-producer also stops a processor with a single real
+        recipe being padded out with longer, roundabout ones. Confirmed links only, filters
+        skipped. Empty when nothing reaches `ptype` by confirmed steps (a likely spec gap).
+        """
+        # Walk producers backward from `ptype`, level by level so the shortest path to each
+        # producer surfaces first. `path` is stored tail-first ([node, ..., ptype]); a
+        # finished chain (one that reached a data source) drops `ptype` off the tail.
+        shortest = {}  # direct producer of ptype -> shortest complete chain ending in it
+        frontier = [[ptype]]
+        for _ in range(4):  # depth cap; deeper chains are not useful examples
+            if not frontier or len(shortest) >= 40:
+                break
+            nxt = []
+            for path in frontier:
+                for producer in self._confirmed_producers(path[0]):
+                    if producer in path:
+                        continue  # don't loop back on a processor already in this path
+                    if self._collector[producer]:
+                        chain = [producer] + path[:-1]  # reached a data source: chain complete
+                        direct = chain[-1]              # the producer `ptype` runs on directly
+                        if direct not in shortest or len(chain) < len(shortest[direct]):
+                            shortest[direct] = chain
+                    else:
+                        nxt.append([producer] + path)
+            frontier = nxt[:400]  # bound the search; plenty for a few short examples
+
+        ranked = sorted(shortest.values(),
+                        key=lambda chain: (-self._match_strength(ptype, chain[-1]),
+                                           len(chain), [self._title(step) for step in chain]))
+        return [{"datasource": chain[0], "title": self._title(chain[0]),
+                 "then": [{"type": step, "title": self._title(step)} for step in chain[1:]]}
+                for chain in ranked[:count]]
 
     def how_to_run(self, ptype):
         """
@@ -299,8 +343,9 @@ class ProcessorMap:
         * a filter answers with a single note -- it runs on almost anything and can be
           inserted anywhere, so listing producers would be noise;
         * otherwise `accepts` is what it runs on directly (its declared requirement +
-          the confirmed data sources and processors), and `starting_points` is where to
-          begin (a data source, and one processor to run first if needed);
+          the confirmed data sources and processors), and `examples` gives a few of the
+          shortest full paths from a data source -- concrete illustrations, not a curated
+          or complete list of ways to get here;
         * `notes` carries the data-source, filter, column and override caveats.
         """
         if self._filter[ptype]:
@@ -329,7 +374,7 @@ class ProcessorMap:
         return {
             "type": ptype,
             "accepts": self._accepts(ptype),
-            "starting_points": self._starting_points(ptype),
+            "examples": self._examples(ptype),
             "notes": notes,
         }
 

--- a/common/lib/processor_map.py
+++ b/common/lib/processor_map.py
@@ -1,0 +1,426 @@
+"""
+Query layer for the processor map: turn the declarative Compatibility + Output specs
+into the questions a user-facing catalogue asks -- browse/search, "how do I run this
+one" (what it accepts + where to start), and "what can run on its output".
+
+The matcher it builds on lives in common/lib/compatibility.py and the output shapes in
+common/lib/outputs.py; this module only builds the producer->consumer graph and reads
+it. Computed purely by inspection -- no datasets, no database. Each link carries a
+yes/maybe answer.
+
+Two ideas keep the answers readable:
+
+* The declared spec is the label. Rather than re-deriving why a producer matched,
+  "how to run" shows the processor's own `describe_spec` (its declared requirement)
+  and lists the producers flat, split only on the one honest distinction: a data
+  source you start from vs. another processor you run first.
+* Filters are transparent. A filter runs on almost any dataset and keeps its format,
+  so it never changes what you can run next and can be inserted anywhere. Filters are
+  therefore kept out of the normal producer lists and noted separately -- their own
+  group under "what can run on this", their own short "how to run".
+"""
+import logging
+
+from collections import defaultdict
+
+from common.lib.compatibility import (
+    Compatibility,
+    describe_spec,
+    is_collector,
+    is_declaratively_compatible,
+    UNKNOWN,
+)
+from common.lib.outputs import describe_output, Filter
+
+_DEFAULT_SPEC = Compatibility(top_dataset_only=True)
+
+
+def _is_filter(processor):
+    """
+    Whether a processor is a filter -- it runs on almost anything, keeps its input's
+    format, and can be inserted anywhere in a chain. True when it declares a Filter
+    output or reports is_filter() (the latter catches filters in the Filtering
+    category that do not declare a Filter output).
+    """
+    if isinstance(getattr(processor, "output", None), Filter):
+        return True
+    is_filter = getattr(processor, "is_filter", None)
+    try:
+        return bool(is_filter()) if callable(is_filter) else bool(is_filter)
+    except Exception:
+        return False
+
+
+def _required_columns(spec):
+    """
+    Columns a spec needs present -- the one prerequisite that can't be met by naming a
+    producer (any dataset with the columns works). Empty when not column-gated.
+    """
+    if spec is None:
+        return []
+    return sorted(set(getattr(spec, "requires_all_columns", None) or [])
+                  | set(getattr(spec, "requires_any_columns", None) or []))
+
+
+def _shape_dict(shape):
+    """A producer's output shape as a JSON-friendly dict ('unknown' for what it left open)."""
+    def show(value):
+        if value is UNKNOWN:
+            return "unknown"
+        if isinstance(value, (set, frozenset)):
+            return sorted(str(item) for item in value)
+        return value
+
+    def show_columns(shape):
+        if shape.columns is UNKNOWN:
+            return "unknown"
+        if not shape.columns and shape.columns_are_all:
+            return "none"
+        return sorted(shape.columns)
+
+    return {
+        "type": shape.type,
+        "extension": show(shape.extension),
+        "media_type": show(shape.media),
+        "datasource": show(shape.datasource),
+        "top_level": show(shape.top_level),
+        "from_collector": show(shape.from_collector),
+        "columns": show_columns(shape),
+        "produces_file": shape.produces_file,
+    }
+
+
+class ProcessorMap:
+    """
+    Built once from the loaded modules; answers the catalogue's questions about how
+    processors connect, from their declared compatibility + output alone.
+    """
+
+    def __init__(self, modules, config=None, logger=None):
+        self.config = config
+        # The frontend passes its Logger (g.log) so a miscalibrated spec reaches the
+        # 4CAT log and, at ERROR, Slack; falls back to stdlib when none is injected.
+        self.log = logger or logging.getLogger(__name__)
+        self.processors = {}
+        self._spec = {}           # declared spec (None when undeclared) -- for display
+        self._match_spec = {}     # effective spec used for matching (default if None)
+        self._shapes = {}         # producer output shape
+        self._collector = {}
+        self._declarative = {}
+        self._filter = {}         # runs on anything, keeps format, inserted anywhere
+
+        # Build per-processor so one bad processor can't take down the whole map: a
+        # `compatibility` that is not a Compatibility (likely a custom extension) is
+        # treated as undeclared and logged at ERROR; one that raises is dropped.
+        for ptype, processor in (getattr(modules, "processors", {}) or {}).items():
+            try:
+                spec = getattr(processor, "compatibility", None)
+                if spec is not None and not isinstance(spec, Compatibility):
+                    self.log.error(
+                        "processor map: processor '%s' has a 'compatibility' that is "
+                        "%s, not a Compatibility -- treating it as undeclared. The "
+                        "spec needs fixing (most likely in a custom extension)."
+                        % (ptype, type(spec).__name__))
+                    spec = None
+                shape = describe_output(processor)
+                collector = is_collector(processor)
+                declarative = is_declaratively_compatible(processor)
+                is_filter = _is_filter(processor)
+            except Exception as e:
+                self.log.error("processor map: processor '%s' could not be read and "
+                               "is omitted from the map: %s" % (ptype, e))
+                continue
+            self.processors[ptype] = processor
+            self._spec[ptype] = spec
+            self._match_spec[ptype] = spec if spec is not None else _DEFAULT_SPEC
+            self._shapes[ptype] = shape
+            self._collector[ptype] = collector
+            self._declarative[ptype] = declarative
+            self._filter[ptype] = is_filter
+
+        # which processors can follow which (datasources never follow anything). Each
+        # link keeps its answer; whether a link is also *approximate* depends on the
+        # following processor (it keeps a custom is_compatible_with), tracked per processor.
+        self._succ = defaultdict(list)
+        self._pred = defaultdict(list)
+        self._edge = {}  # (producer, consumer) -> MatchResult
+        for ptype in self.processors:
+            shape = self._shapes[ptype]
+            # a processor that writes no result file (e.g. only annotates its parent)
+            # produces nothing for another processor to run on
+            if not shape.produces_file:
+                continue
+            for qtype in self.processors:
+                if qtype == ptype or self._collector[qtype]:
+                    continue
+                try:
+                    outcome = self._match_spec[qtype].check(shape)  # "yes" / "maybe" / "no"
+                except Exception as e:
+                    self.log.warning("processor map: edge %s -> %s skipped: %s" % (ptype, qtype, e))
+                    continue
+                if outcome != "no":
+                    self._succ[ptype].append(qtype)
+                    self._pred[qtype].append(ptype)
+                    self._edge[(ptype, qtype)] = "definite" if outcome == "yes" else "maybe"
+
+    # -- catalogue / search --
+
+    def _entry(self, ptype):
+        processor = self.processors[ptype]
+        spec = self._spec[ptype]
+        return {
+            "type": ptype,
+            "title": getattr(processor, "title", ptype),
+            "category": getattr(processor, "category", None),
+            "description": getattr(processor, "description", None),
+            "is_datasource": self._collector[ptype],
+            "is_filter": self._filter[ptype],
+            "has_override": not self._declarative[ptype],
+            "requires_dataset_result_file": bool(
+                spec is not None and getattr(spec, "requires_dataset_result_file", False)),
+        }
+
+    def catalogue(self):
+        """Every processor (and datasource), each with display metadata + flags."""
+        return [self._entry(ptype) for ptype in self.processors]
+
+    def categories(self):
+        """{category: [sorted types]} for grouped browsing."""
+        groups = defaultdict(list)
+        for ptype in self.processors:
+            groups[getattr(self.processors[ptype], "category", None) or "(uncategorised)"].append(ptype)
+        return {category: sorted(types) for category, types in sorted(groups.items())}
+
+    def search(self, query):
+        """Catalogue entries whose type/title/category/description contains `query`."""
+        needle = (query or "").strip().lower()
+        if not needle:
+            return []
+        hits = []
+        for ptype in self.processors:
+            entry = self._entry(ptype)
+            haystack = " ".join(str(entry.get(field) or "") for field in
+                                ("type", "title", "category", "description")).lower()
+            if needle in haystack:
+                hits.append(entry)
+        return hits
+
+    # -- one processor --
+
+    def processor(self, ptype):
+        """Full bundle for one processor: metadata, spec, how-to-run, follow-ups."""
+        if ptype not in self.processors:
+            return None
+        return {
+            **self._entry(ptype),
+            "output_shape": _shape_dict(self._shapes[ptype]),
+            "compatibility": describe_spec(self._spec[ptype]),
+            "how_to_run": self.how_to_run(ptype),
+            "followups": self.followups(ptype),
+        }
+
+    def _title(self, ptype):
+        return getattr(self.processors[ptype], "title", ptype) if ptype in self.processors else ptype
+
+    def _step(self, ptype, certainty=None):
+        """A producer step, optionally annotated with the certainty of its link."""
+        step = {"type": ptype, "title": self._title(ptype),
+                "is_datasource": self._collector.get(ptype, False)}
+        if certainty is not None:
+            step["certainty"] = certainty
+        return step
+
+    def _producers(self, ptype, certainty=None):
+        """The processors whose output `ptype` accepts; with `certainty` set
+        ("definite" or "maybe"), only the producers whose link has that certainty."""
+        producers = []
+        for producer in self._pred.get(ptype, []):
+            edge = self._edge.get((producer, ptype))
+            if certainty is None or edge == certainty:
+                producers.append(producer)
+        return producers
+
+    def _reachable_sources(self, node, cache, stack):
+        """The data sources reachable from `node` by following confirmed (definite)
+        links back. Memoised in `cache`; `stack` guards against cycles. Linear in the
+        size of the confirmed graph -- it collects a set, it does not enumerate paths."""
+        if node in cache:
+            return cache[node]
+        sources = set()
+        for producer in self._producers(node, "definite"):
+            if self._collector[producer]:
+                sources.add(producer)
+            elif producer not in stack and not self._filter[producer]:
+                sources |= self._reachable_sources(producer, cache, stack | {producer})
+        cache[node] = sources
+        return sources
+
+    # -- how to run one processor --
+
+    def _accepts(self, ptype):
+        """
+        What `ptype` runs on directly. The declared requirement is the label (its own
+        `describe_spec`); the confirmed producers are listed flat, split only on the
+        one honest distinction -- a data source you start from vs. another processor
+        you run first. Filters are left out: they are transparent (see followups).
+        """
+        confirmed = self._producers(ptype, "definite")
+        datasources = sorted(p for p in confirmed if self._collector[p])
+        from_processors = sorted(p for p in confirmed
+                                 if not self._collector[p] and not self._filter[p])
+        # the declared spec is the label, but only its *input* conditions -- the
+        # follow-up hints describe this processor's output, not what it accepts
+        requirement = describe_spec(self._spec[ptype]) or {}
+        requirement = {key: value for key, value in requirement.items()
+                       if key not in ("preferred_followups", "excluded_followups")}
+        return {
+            "requirement": requirement,
+            "datasources": [self._step(p, self._edge.get((p, ptype))) for p in datasources],
+            "from_processors": [self._step(p, self._edge.get((p, ptype))) for p in from_processors],
+        }
+
+    def _starting_points(self, ptype):
+        """
+        Where to begin: the data sources from which `ptype` is reachable by confirmed
+        links. A source `ptype` accepts directly has an empty `then` (run it straight
+        away); otherwise `then` names one processor to run first. Filters are skipped
+        (transparent), so a route is never padded with them.
+        """
+        cache = {}
+        routes = {}  # datasource -> [processors to run first]
+        definite = self._producers(ptype, "definite")
+        for producer in definite:
+            if self._collector[producer]:
+                routes[producer] = []
+        for producer in definite:
+            if self._collector[producer] or self._filter[producer]:
+                continue
+            for source in self._reachable_sources(producer, cache, {ptype, producer}):
+                if source not in routes:
+                    routes[source] = [producer]
+        return [{"datasource": source, "title": self._title(source),
+                 "then": [{"type": step, "title": self._title(step)} for step in then]}
+                for source, then in sorted(routes.items())]
+
+    def how_to_run(self, ptype):
+        """
+        How to produce a dataset `ptype` can run on:
+
+        * a filter answers with a single note -- it runs on almost anything and can be
+          inserted anywhere, so listing producers would be noise;
+        * otherwise `accepts` is what it runs on directly (its declared requirement +
+          the confirmed data sources and processors), and `starting_points` is where to
+          begin (a data source, and one processor to run first if needed);
+        * `notes` carries the data-source, filter, column and override caveats.
+        """
+        if self._filter[ptype]:
+            return {
+                "type": ptype,
+                "is_filter": True,
+                "notes": ["This is a filter: it runs on almost any dataset and can be "
+                          "inserted at any point in a chain. Its output keeps the same "
+                          "format, so it does not change what you can run next."],
+            }
+
+        columns = _required_columns(self._spec[ptype])
+        notes = []
+        if self._collector[ptype]:
+            notes.append("This is a data source: it collects data directly (from an upload "
+                         "or a query), so it does not run on another dataset.")
+        else:
+            notes.append("Filters can be applied at any earlier point -- they keep the "
+                         "format, so they do not change what this accepts.")
+        if columns:
+            notes.append("Needs a dataset with these columns (%s); the producing processor "
+                         "can't be named from the specs alone." % ", ".join(columns))
+        if not self._declarative[ptype]:
+            notes.append("Keeps a custom is_compatible_with, so these connections are approximate.")
+
+        return {
+            "type": ptype,
+            "accepts": self._accepts(ptype),
+            "starting_points": self._starting_points(ptype),
+            "notes": notes,
+        }
+
+    def _effective_followups(self, ptype):
+        """
+        The consumers that can run on `ptype`'s output, as {consumer: certainty}.
+
+        For an ordinary processor this is just its outgoing edges. For a filter it is
+        resolved by propagation instead: a filter's output has the same shape as its
+        input, so anything that runs on what fed the filter also runs on the filtered
+        result. Because a filter accepts almost anything, every data source or processor
+        that can reach it is one of its direct producers, so reading its non-filter
+        producers (and what runs on each of them) resolves the followups without a walk.
+        This turns a filter's followups from the blanket "maybe" its own unknown shape
+        gives into the concrete, mostly-definite set it really has.
+        """
+        if not self._filter[ptype]:
+            return {consumer: self._edge[(ptype, consumer)]
+                    for consumer in self._succ.get(ptype, [])}
+        resolved = {}
+        for producer in self._pred.get(ptype, []):
+            if self._filter[producer]:
+                continue  # another filter gives no concrete shape to propagate
+            into_filter = self._edge[(producer, ptype)]
+            for consumer in self._succ.get(producer, []):
+                if consumer == ptype:
+                    continue
+                certainty = ("definite" if into_filter == "definite"
+                             and self._edge[(producer, consumer)] == "definite" else "maybe")
+                if resolved.get(consumer) != "definite":
+                    resolved[consumer] = certainty
+        return resolved
+
+    def followups(self, ptype):
+        """
+        What can run on `ptype`'s output: curated `preferred` first, then `filters`
+        (kept separate -- a filter can be applied to narrow the data without changing
+        its format), then the real analysis steps grouped by category. For a filter the
+        set is resolved by propagation (see _effective_followups) and a note explains it.
+        """
+        spec = self._spec[ptype]
+        preferred = [followup for followup in (getattr(spec, "preferred_followups", None) or [])
+                     if followup in self.processors]
+        preferred_set = set(preferred)
+        filters = []
+        grouped = defaultdict(list)
+        for qtype, certainty in self._effective_followups(ptype).items():
+            if qtype in preferred_set:
+                continue
+            item = {
+                "type": qtype,
+                "title": getattr(self.processors[qtype], "title", qtype),
+                "certainty": certainty,
+                "approximate": not self._declarative[qtype],
+            }
+            if self._filter[qtype]:
+                filters.append(item)
+            else:
+                category = getattr(self.processors[qtype], "category", None) or "(uncategorised)"
+                grouped[category].append(item)
+        result = {
+            "preferred": [self._entry(followup) for followup in preferred],
+            "filters": sorted(filters, key=lambda item: item["type"]),
+            "others_by_category": {category: sorted(items, key=lambda item: item["type"])
+                                   for category, items in sorted(grouped.items())},
+        }
+        if self._filter[ptype]:
+            result["note"] = ("A filter keeps its input's format, so anything you could run on "
+                              "the dataset you filtered you can still run here.")
+        return result
+
+    def graph(self):
+        """
+        The whole map as {nodes, edges} -- the producer->consumer backbone the query
+        methods traverse, exposed for graph-drawing and debugging. Nodes carry
+        `is_root` (alias of is_datasource); edges carry the outcome certainty and
+        whether the consumer is approximate (keeps an override).
+        """
+        nodes = [{**self._entry(ptype), "is_root": self._collector[ptype]} for ptype in self.processors]
+        edges = [{"from": producer, "to": consumer,
+                  "certainty": self._edge[(producer, consumer)],
+                  "approximate": not self._declarative[consumer]}
+                 for producer, consumers in self._succ.items() for consumer in consumers]
+        return {"nodes": nodes, "edges": edges}

--- a/common/lib/processor_map.py
+++ b/common/lib/processor_map.py
@@ -240,21 +240,6 @@ class ProcessorMap:
                 producers.append(producer)
         return producers
 
-    def _reachable_sources(self, node, cache, stack):
-        """The data sources reachable from `node` by following confirmed (definite)
-        links back. Memoised in `cache`; `stack` guards against cycles. Linear in the
-        size of the confirmed graph -- it collects a set, it does not enumerate paths."""
-        if node in cache:
-            return cache[node]
-        sources = set()
-        for producer in self._producers(node, "definite"):
-            if self._collector[producer]:
-                sources.add(producer)
-            elif producer not in stack and not self._filter[producer]:
-                sources |= self._reachable_sources(producer, cache, stack | {producer})
-        cache[node] = sources
-        return sources
-
     # -- how to run one processor --
 
     def _accepts(self, ptype):
@@ -281,22 +266,27 @@ class ProcessorMap:
 
     def _starting_points(self, ptype):
         """
-        Where to begin: the data sources from which `ptype` is reachable by confirmed
-        links. A source `ptype` accepts directly has an empty `then` (run it straight
-        away); otherwise `then` names one processor to run first. Filters are skipped
-        (transparent), so a route is never padded with them.
+        The sensible places to start: a data source you can run this on directly, or one
+        you can run it on after a single processor. The cap of one step is deliberate -- a
+        source only counts if it (or one processor run on it) directly produces something
+        this accepts. Longer routes usually exist, but reaching a processor through many
+        hops is seldom the sensible way in and would bury the obvious starts under every
+        distant path; those are found by opening the processors along the way. A source it
+        accepts directly has an empty `then` (run it straight away); otherwise `then` names
+        the one processor to run first. Filters are skipped (transparent).
         """
-        cache = {}
-        routes = {}  # datasource -> [processors to run first]
-        definite = self._producers(ptype, "definite")
-        for producer in definite:
+        routes = {}  # datasource -> [processor to run first]; [] means run it straight away
+        producers = self._producers(ptype, "definite")
+        # data sources this runs on directly
+        for producer in producers:
             if self._collector[producer]:
                 routes[producer] = []
-        for producer in definite:
+        # data sources one step removed: source -> producer -> this, both links confirmed
+        for producer in producers:
             if self._collector[producer] or self._filter[producer]:
                 continue
-            for source in self._reachable_sources(producer, cache, {ptype, producer}):
-                if source not in routes:
+            for source in self._producers(producer, "definite"):
+                if self._collector[source] and source not in routes:
                     routes[source] = [producer]
         return [{"datasource": source, "title": self._title(source),
                  "then": [{"type": step, "title": self._title(step)} for step in then]}

--- a/datasources/audio_to_text/audio_to_text.py
+++ b/datasources/audio_to_text/audio_to_text.py
@@ -8,6 +8,7 @@ of their processors and skip those two datasource only methods).
 
 from datasources.media_import.import_media import SearchMedia
 from processors.machine_learning.audio_to_text import AudioToText
+from common.lib.outputs import MediaArchive
 
 
 class AudioUploadToText(SearchMedia):
@@ -16,6 +17,9 @@ class AudioUploadToText(SearchMedia):
     title = "Convert speech to text"  # title displayed in UI
     description = "Upload your own audio and use OpenAI's Whisper or GPT models to create transcripts"  # description displayed in UI
     icon = "closed-captioning"
+
+    # only audio is accepted here, so the output media is narrower than SearchMedia's
+    output = MediaArchive(media="audio", collector=True, position="top")
 
     # reuse the AudioToText processor's compatibility -- this datasource runs it on uploaded audio
     compatibility = AudioToText.compatibility

--- a/datasources/bsky/search_bsky.py
+++ b/datasources/bsky/search_bsky.py
@@ -17,6 +17,7 @@ from common.lib.exceptions import QueryParametersException, QueryNeedsExplicitCo
 from common.lib.helpers import timify
 from common.lib.user_input import UserInput
 from common.lib.item_mapping import MappedItem
+from common.lib.outputs import Datasource
 
 class SearchBluesky(Search):
     """
@@ -27,6 +28,8 @@ class SearchBluesky(Search):
     title = "Bluesky Search"  # title displayed in UI
     description = "Collects Bluesky posts via its API."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"tags"})
     is_local = False  # Whether this datasource is locally scraped
     is_static = False  # Whether this datasource is still updated
     icon = "brand-bluesky"

--- a/datasources/dmi-tcat/search_tcat.py
+++ b/datasources/dmi-tcat/search_tcat.py
@@ -13,6 +13,7 @@ from common.lib.exceptions import QueryParametersException
 from common.lib.user_input import UserInput
 from common.lib.helpers import sniff_encoding
 from common.lib.item_mapping import MappedItem
+from common.lib.outputs import Datasource
 
 from datasources.twitterv2.search_twitter import SearchWithTwitterAPIv2
 
@@ -26,6 +27,7 @@ class SearchWithinTCATBins(Search):
     """
     type = "dmi-tcat-search"  # job ID
     extension = "ndjson"
+    output = Datasource()
     title = "TCAT Search (HTTP)"
     icon = "brand-twitter"
 

--- a/datasources/dmi-tcatv2/search_tcat_v2.py
+++ b/datasources/dmi-tcatv2/search_tcat_v2.py
@@ -11,6 +11,7 @@ import pymysql
 from backend.lib.search import Search
 from common.lib.exceptions import QueryParametersException
 from common.lib.user_input import UserInput
+from common.lib.outputs import Datasource
 from backend.lib.database_mysql import MySQLDatabase
 
 
@@ -23,6 +24,7 @@ class SearchWithinTCATBinsV2(Search):
     """
     type = "dmi-tcatv2-search"  # job ID
     extension = "csv"
+    output = Datasource()
     title = "TCAT Search (SQL)"
     icon = "brand-twitter"
 

--- a/datasources/douban/search_douban.py
+++ b/datasources/douban/search_douban.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 from backend.lib.search import Search
 from common.lib.helpers import convert_to_int, strip_tags, UserInput
 from common.lib.exceptions import QueryParametersException, ProcessorInterruptedException
+from common.lib.outputs import Datasource
 
 
 class SearchDouban(Search):
@@ -24,6 +25,7 @@ class SearchDouban(Search):
     title = "Douban Search"  # title displayed in UI
     description = "Scrapes group posts from Douban for a given set of groups"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_local = False    # Whether this datasource is locally scraped
     is_static = False   # Whether this datasource is still updated
     icon = "comment"

--- a/datasources/douyin/search_douyin.py
+++ b/datasources/douyin/search_douyin.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem, MissingMappedField
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 class SearchDouyin(Search):
     """
@@ -18,6 +19,8 @@ class SearchDouyin(Search):
     title = "Import scraped Douyin data"  # title displayed in UI
     description = "Import Douyin data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     icon = "brand-tiktok"
 

--- a/datasources/eightchan/search_8chan.py
+++ b/datasources/eightchan/search_8chan.py
@@ -4,6 +4,7 @@
 from datasources.fourchan.search_4chan import Search4Chan
 
 from common.lib.helpers import UserInput
+from common.lib.outputs import Datasource
 
 
 class Search8Chan(Search4Chan):
@@ -16,6 +17,7 @@ class Search8Chan(Search4Chan):
     most methods are inherited from there.
     """
     type = "eightchan-search"
+    output = Datasource()
     sphinx_index = "8chan"
     title = "8chan search"
     prefix = "8chan"

--- a/datasources/eightkun/search_8kun.py
+++ b/datasources/eightkun/search_8kun.py
@@ -4,6 +4,7 @@
 from datasources.fourchan.search_4chan import Search4Chan
 
 from common.lib.helpers import UserInput
+from common.lib.outputs import Datasource
 
 
 class Search8Kun(Search4Chan):
@@ -16,6 +17,7 @@ class Search8Kun(Search4Chan):
     most methods are inherited from there.
     """
     type = "eightkun-search"
+    output = Datasource()
     sphinx_index = "8kun"
     title = "8kun search"
     prefix = "8kun"

--- a/datasources/facebook/search_facebook.py
+++ b/datasources/facebook/search_facebook.py
@@ -9,6 +9,7 @@ import json
 
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
+from common.lib.outputs import Datasource
 
 
 class SearchFacebook(Search):
@@ -20,6 +21,7 @@ class SearchFacebook(Search):
     title = "Import scraped Facebook data"  # title displayed in UI
     description = "Import Facebook data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_from_zeeschuimer = True
 
     # not available as a processor for existing datasets

--- a/datasources/fourcat_import/import_4cat.py
+++ b/datasources/fourcat_import/import_4cat.py
@@ -13,6 +13,7 @@ from common.lib.exceptions import (QueryParametersException, FourcatException, P
                                    DataSetException)
 from common.lib.helpers import UserInput, get_software_version
 from common.lib.dataset import DataSet
+from common.lib.outputs import Output
 
 
 class FourcatImportException(FourcatException):
@@ -26,6 +27,9 @@ class SearchImportFromFourcat(BasicProcessor):
     description = "Import a dataset from another 4CAT server or from a zip file (exported from a 4CAT server)"  # description displayed in UI
     is_local = False  # Whether this datasource is locally scraped
     is_static = False  # Whether this datasource is still updated
+    # a top-level import; extension, media and columns are copied from whatever dataset
+    # is imported, so none of them are known ahead of the run
+    output = Output(extension=None, media=None, columns=None, position="top", collector=True)
     icon = "file-import"
 
     max_workers = 1  # this cannot be more than 1, else things get VERY messy

--- a/datasources/fourchan/search_4chan.py
+++ b/datasources/fourchan/search_4chan.py
@@ -9,6 +9,7 @@ from pymysql.err import Warning as SphinxWarning
 
 from backend.lib.database_mysql import MySQLDatabase
 from common.lib.helpers import UserInput
+from common.lib.outputs import Datasource
 from backend.lib.search import SearchWithScope
 from common.lib.exceptions import QueryParametersException, ProcessorInterruptedException
 
@@ -20,6 +21,7 @@ class Search4Chan(SearchWithScope):
     Defines methods that are used to query the 4chan data indexed and saved.
     """
     type = "fourchan-search"  # job ID
+    output = Datasource()
     title = "4chan search"
     sphinx_index = "4chan"  # sphinx index name; this should match the index name in sphinx.conf
     prefix = "4chan"  # table identifier for this datasource; see below for usage

--- a/datasources/gab/search_gab.py
+++ b/datasources/gab/search_gab.py
@@ -5,6 +5,7 @@ import datetime
 
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem, MissingMappedField
+from common.lib.outputs import Datasource
 from common.lib.helpers import normalize_url_encoding
 
 
@@ -17,6 +18,8 @@ class SearchGab(Search):
     title = "Import scraped Gab data"  # title displayed in UI
     description = "Import Gab data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"tags"})
     is_from_zeeschuimer = True
     fake = ""
 

--- a/datasources/imgur/search_imgur.py
+++ b/datasources/imgur/search_imgur.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
+from common.lib.outputs import Datasource
 from common.lib.helpers import normalize_url_encoding
 
 class SearchImgur(Search):
@@ -19,6 +20,7 @@ class SearchImgur(Search):
     title = "Import scraped Imgur data"  # title displayed in UI
     description = "Import Imgur data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_from_zeeschuimer = True
 
     # not available as a processor for existing datasets

--- a/datasources/instagram/search_instagram.py
+++ b/datasources/instagram/search_instagram.py
@@ -9,6 +9,7 @@ import re
 
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem, MissingMappedField
+from common.lib.outputs import Datasource
 from common.lib.exceptions import MapItemException
 from common.lib.helpers import normalize_url_encoding
 
@@ -22,6 +23,8 @@ class SearchInstagram(Search):
     title = "Import scraped Instagram data"  # title displayed in UI
     description = "Import Instagram data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     icon = "brand-instagram"
 

--- a/datasources/linkedin/search_linkedin.py
+++ b/datasources/linkedin/search_linkedin.py
@@ -12,6 +12,7 @@ import re
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 class SearchLinkedIn(Search):
     """
@@ -22,6 +23,8 @@ class SearchLinkedIn(Search):
     title = "Import scraped LinkedIn data"  # title displayed in UI
     description = "Import LinkedIn data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     icon = "brand-linkedin"
 

--- a/datasources/media_import/import_media.py
+++ b/datasources/media_import/import_media.py
@@ -9,6 +9,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.exceptions import QueryParametersException, QueryNeedsExplicitConfirmationException
 from common.lib.user_input import UserInput
 from common.lib.helpers import andify
+from common.lib.outputs import MediaArchive
 
 class SearchMedia(BasicProcessor):
     type = "media-import-search"  # job ID
@@ -19,6 +20,10 @@ class SearchMedia(BasicProcessor):
     is_local = False  # Whether this datasource is locally scraped
     is_static = False  # Whether this datasource is still updated
     icon = "images"
+
+    # A top-level archive of uploaded media; one upload is a single media type, but
+    # which one is only known at run time, so the output media is that bounded set.
+    output = MediaArchive(media={"image", "video", "audio"}, collector=True, position="top")
 
     max_workers = 1
 

--- a/datasources/ninegag/search_9gag.py
+++ b/datasources/ninegag/search_9gag.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchNineGag(Search):
@@ -20,6 +21,8 @@ class SearchNineGag(Search):
     title = "Import scraped 9gag data"  # title displayed in UI
     description = "Import 9gag data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"tags"})
     is_from_zeeschuimer = True
 
     # not available as a processor for existing datasets

--- a/datasources/pinterest/search_pinterest.py
+++ b/datasources/pinterest/search_pinterest.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem, MissingMappedField
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchPinterest(Search):
@@ -20,6 +21,7 @@ class SearchPinterest(Search):
     title = "Import scraped Pinterest data"  # title displayed in UI
     description = "Import Pinterest data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_from_zeeschuimer = True
     icon = "brand-pinterest"
 

--- a/datasources/telegram/search_telegram.py
+++ b/datasources/telegram/search_telegram.py
@@ -14,6 +14,7 @@ from common.lib.exceptions import QueryParametersException, ProcessorInterrupted
     QueryNeedsFurtherInputException
 from common.lib.helpers import convert_to_int, UserInput
 from common.lib.item_mapping import MappedItem, MissingMappedField
+from common.lib.outputs import Datasource
 
 from datetime import datetime
 from telethon import TelegramClient, utils
@@ -34,6 +35,7 @@ class SearchTelegram(Search):
     title = "Telegram API search"  # title displayed in UI
     description = "Scrapes messages from open Telegram groups via its API."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_local = False  # Whether this datasource is locally scraped
     is_static = False  # Whether this datasource is still updated
     icon = "brand-telegram"

--- a/datasources/test/search_test.py
+++ b/datasources/test/search_test.py
@@ -23,6 +23,7 @@ from backend.lib.search import Search
 from common.lib.user_input import UserInput
 from common.lib.item_mapping import MappedItem
 from common.lib.exceptions import ProcessorInterruptedException, ProcessorException
+from common.lib.outputs import Datasource
 
 # only make this worker available when explicitly enabled, so it never loads on
 # a normal/production instance (the datasource folder is always discovered, but
@@ -40,6 +41,7 @@ if TEST_DATASOURCE_ENABLED:
         title = "Test datasource (dev only)"  # title displayed in UI
         description = "Development-only datasource that creates dummy datasets in various states (complete, forever, crash) to exercise admin status pages."
         extension = "ndjson"  # extension of result file
+        output = Datasource()
 
         # not offered as a processor for existing datasets
         accepts = [None]

--- a/datasources/threads/search_threads.py
+++ b/datasources/threads/search_threads.py
@@ -11,6 +11,7 @@ import re
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchThreads(Search):
@@ -22,6 +23,8 @@ class SearchThreads(Search):
     title = "Import scraped Threads data"  # title displayed in UI
     description = "Import Threads data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     icon = "brand-threads"
 

--- a/datasources/tiktok/search_tiktok.py
+++ b/datasources/tiktok/search_tiktok.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse, parse_qs
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchTikTok(Search):
@@ -21,6 +22,8 @@ class SearchTikTok(Search):
     title = "Import scraped Tiktok data"  # title displayed in UI
     description = "Import Tiktok data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     icon = "brand-tiktok"
 

--- a/datasources/tiktok_comments/search_tiktok_comments.py
+++ b/datasources/tiktok_comments/search_tiktok_comments.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem, MissingMappedField
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchTikTokComments(Search):
@@ -20,6 +21,7 @@ class SearchTikTokComments(Search):
     title = "Import scraped Tiktok comment data"  # title displayed in UI
     description = "Import Tiktok comment data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_from_zeeschuimer = True
     icon = "brand-tiktok"
 

--- a/datasources/tiktok_urls/search_tiktok_urls.py
+++ b/datasources/tiktok_urls/search_tiktok_urls.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 
 from backend.lib.search import Search
 from common.lib.helpers import UserInput
+from common.lib.outputs import Datasource
 from common.lib.exceptions import WorkerInterruptedException, QueryParametersException, ProcessorException
 from datasources.tiktok.search_tiktok import SearchTikTok as SearchTikTokByImport
 
@@ -33,6 +34,8 @@ class SearchTikTokByID(Search):
     title = "Search TikTok by post URL"  # title displayed in UI
     description = "Retrieve metadata for TikTok post URLs."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_local = False  # Whether this datasource is locally scraped
     is_static = False  # Whether this datasource is still updated
     icon = "brand-tiktok"

--- a/datasources/truth/search_truth.py
+++ b/datasources/truth/search_truth.py
@@ -6,6 +6,7 @@ import datetime
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchGab(Search):
@@ -17,6 +18,8 @@ class SearchGab(Search):
     title = "Import scraped Truth Social data"  # title displayed in UI
     description = "Import Truth Social data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     fake = ""
 

--- a/datasources/tumblr/search_tumblr.py
+++ b/datasources/tumblr/search_tumblr.py
@@ -20,6 +20,7 @@ from backend.lib.search import Search
 from common.lib.helpers import UserInput, strip_tags
 from common.lib.exceptions import QueryParametersException, ProcessorInterruptedException, ConfigException
 from common.lib.item_mapping import MappedItem
+from common.lib.outputs import Datasource
 
 __author__ = "Sal Hagen"
 __credits__ = ["Sal Hagen", "Tumblr API (api.tumblr.com)"]
@@ -36,6 +37,8 @@ class SearchTumblr(Search):
 	title = "Search Tumblr"  # title displayed in UI
 	description = "Retrieve Tumblr posts by tags or blogs."  # description displayed in UI
 	extension = "ndjson"  # extension of result file, used internally and in UI
+	# the tag column the co-tag and hashtag networks look for
+	output = Datasource(columns={"tags"})
 	is_local = False  # Whether this datasource is locally scraped
 	is_static = False  # Whether this datasource is still updated
 	icon = "brand-tumblr"

--- a/datasources/twitter-import/search_twitter.py
+++ b/datasources/twitter-import/search_twitter.py
@@ -11,6 +11,7 @@ from backend.lib.search import Search
 from common.lib.helpers import strip_tags
 from common.lib.item_mapping import MappedItem
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchTwitterViaZeeschuimer(Search):
@@ -22,6 +23,8 @@ class SearchTwitterViaZeeschuimer(Search):
     title = "Import scraped X/Twitter data"  # title displayed in UI
     description = "Import X/Twitter data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
     icon = "brand-x-twitter"
 

--- a/datasources/twitterv2/search_twitter.py
+++ b/datasources/twitterv2/search_twitter.py
@@ -12,6 +12,7 @@ from backend.lib.search import Search
 from common.lib.exceptions import QueryParametersException, ProcessorInterruptedException, QueryNeedsExplicitConfirmationException
 from common.lib.helpers import convert_to_int, UserInput, timify
 from common.lib.item_mapping import MappedItem, MissingMappedField
+from common.lib.outputs import Datasource
 
 
 class SearchWithTwitterAPIv2(Search):
@@ -21,6 +22,8 @@ class SearchWithTwitterAPIv2(Search):
     type = "twitterv2-search"  # job ID
     title = "X/Twitter API (v2)"
     extension = "ndjson"
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_local = False    # Whether this datasource is locally scraped
     is_static = False   # Whether this datasource is still updated
     icon = "brand-twitter"

--- a/datasources/upload/import_csv.py
+++ b/datasources/upload/import_csv.py
@@ -14,6 +14,7 @@ from dateutil.parser import parse as parse_datetime
 from datetime import datetime
 
 from backend.lib.processor import BasicProcessor
+from common.lib.outputs import Datasource
 from common.lib.exceptions import QueryParametersException, QueryNeedsFurtherInputException, \
     QueryNeedsExplicitConfirmationException, CsvDialectException
 from common.lib.helpers import strip_tags, sniff_encoding, UserInput, HashCache
@@ -25,6 +26,8 @@ class SearchCustom(BasicProcessor):
     title = "Custom Dataset Upload"  # title displayed in UI
     description = "Upload your own CSV file to be used as a dataset"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a collected, top-level csv; the columns depend on the uploaded file, so unknown here
+    output = Datasource()
     is_local = False  # Whether this datasource is locally scraped
     is_static = False  # Whether this datasource is still updated
     icon = "file-import"

--- a/datasources/vk/search_vk.py
+++ b/datasources/vk/search_vk.py
@@ -9,6 +9,7 @@ from backend.lib.search import Search
 from common.lib.exceptions import QueryParametersException, ProcessorInterruptedException, ProcessorException
 from common.lib.helpers import UserInput
 from common.lib.item_mapping import MappedItem
+from common.lib.outputs import Datasource
 
 
 class SearchVK(Search):
@@ -18,6 +19,7 @@ class SearchVK(Search):
     type = "vk-search"  # job ID
     title = "VK"
     extension = "ndjson"
+    output = Datasource()
     is_local = False    # Whether this datasource is locally scraped
     is_static = False   # Whether this datasource is still updated
     icon = "brand-vk"

--- a/datasources/xiaohongshu/search_rednote.py
+++ b/datasources/xiaohongshu/search_rednote.py
@@ -12,6 +12,7 @@ from backend.lib.search import Search
 from common.lib.exceptions import MapItemException
 from common.lib.item_mapping import MappedItem, MissingMappedField
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchRedNote(Search):
@@ -23,6 +24,8 @@ class SearchRedNote(Search):
     title = "Import scraped RedNote data"  # title displayed in UI
     description = "Import RedNote data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # the tag column the co-tag and hashtag networks look for
+    output = Datasource(columns={"hashtags"})
     is_from_zeeschuimer = True
 
     # not available as a processor for existing datasets

--- a/datasources/xiaohongshu_comments/search_rednote_comments.py
+++ b/datasources/xiaohongshu_comments/search_rednote_comments.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from backend.lib.search import Search
 from common.lib.item_mapping import MappedItem, MissingMappedField
 from common.lib.helpers import normalize_url_encoding
+from common.lib.outputs import Datasource
 
 
 class SearchRedNoteComments(Search):
@@ -20,6 +21,7 @@ class SearchRedNoteComments(Search):
     title = "Import scraped RedNote comment data"  # title displayed in UI
     description = "Import RedNote comment data collected with an external tool such as Zeeschuimer."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    output = Datasource()
     is_from_zeeschuimer = True
 
     # not available as a processor for existing datasets

--- a/processors/audio/audio_extractor.py
+++ b/processors/audio/audio_extractor.py
@@ -11,6 +11,7 @@ import oslex
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility, is_executable
+from common.lib.outputs import MediaArchive
 from common.lib.exceptions import ProcessorInterruptedException
 
 __author__ = "Dale Wahl"
@@ -32,6 +33,8 @@ class AudioExtractor(BasicProcessor):
     title = "Extract audio from videos"  # title displayed in UI
     description = "Create audio files per video"  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
+    # a zip archive of media files
+    output = MediaArchive(media="audio")
     media_type = "audio"
     icon = "closed-captioning"
 

--- a/processors/audio/audio_extractor.py
+++ b/processors/audio/audio_extractor.py
@@ -39,7 +39,7 @@ class AudioExtractor(BasicProcessor):
     icon = "closed-captioning"
 
     # Allow on video datasets when ffmpeg is available
-    compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)}, preferred_followups=["audio-to-text"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)}, preferred_followups=["audio-to-text"])
 
     @classmethod
     def get_options(cls, parent_dataset=None, config=None):

--- a/processors/conversion/clarifai_to_csv.py
+++ b/processors/conversion/clarifai_to_csv.py
@@ -5,6 +5,7 @@ import csv
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -28,6 +29,9 @@ class ConvertClarifaiOutputToCSV(BasicProcessor):
     description = "Convert the Clarifai API output to a simplified CSV file."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
     icon = "file-csv"
+
+    # a derived table
+    output = Table()
 
     # Allow processor on Clarifai API output
     compatibility = Compatibility(types={"clarifai-api"})

--- a/processors/conversion/consolidate_urls.py
+++ b/processors/conversion/consolidate_urls.py
@@ -9,6 +9,7 @@ from processors.conversion.extract_urls import ExtractURLs
 from common.lib.exceptions import ProcessorInterruptedException
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.helpers import UserInput, split_urls
 
 __author__ = "Dale Wahl"
@@ -28,6 +29,8 @@ class ConsolidateURLs(BasicProcessor):
     title = "Consolidate URLs"  # title displayed in UI
     description = "Retain only the domain (and optionally path) of URLs; used for custom networks (e.g. author + domains)"
     extension = "csv"
+    # a derived table
+    output = Table()
     icon = "globe"
 
     # Allow on CSV/NDJSON datasets

--- a/processors/conversion/convert_text.py
+++ b/processors/conversion/convert_text.py
@@ -7,6 +7,7 @@ import csv
 from common.lib.exceptions import ProcessorInterruptedException
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.helpers import UserInput
 
 __author__ = "Sal Hagen"
@@ -26,6 +27,9 @@ class ConvertText(BasicProcessor):
                    "also be added to the original dataset as annotations.")  # description displayed in UI
     extension = "csv"
     icon = "arrow-turn-to-dots"
+
+    # a derived table
+    output = Table()
 
     # Allow on CSV/NDJSON datasets
     compatibility = Compatibility(extensions={"csv", "ndjson"})

--- a/processors/conversion/csv_to_json.py
+++ b/processors/conversion/csv_to_json.py
@@ -5,6 +5,7 @@ import json
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import File
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -20,6 +21,8 @@ class ConvertCSVToJSON(BasicProcessor):
 	title = "Convert to JSON"  # title displayed in UI
 	description = "Change a CSV file to a JSON file"  # description displayed in UI
 	extension = "json"  # extension of result file, used internally and in UI
+	# a single json file
+	output = File("json")
 	icon = "square-js"
 
 	# Allow on CSV datasets

--- a/processors/conversion/export_datasets.py
+++ b/processors/conversion/export_datasets.py
@@ -9,6 +9,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.dataset import DataSet
 from common.lib.exceptions import DataSetException
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Archive
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -27,6 +28,8 @@ class ExportDatasets(BasicProcessor):
 	description = ("Creates a ZIP file containing the dataset and all processor results. This can also be uploaded to "
 				   "another 4CAT instance. Filters are not included. Results expire after one day.")  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
+	# a zip archive of data files
+	output = Archive()
 	icon = "file-export"
 
 	# coarse map spec; is_compatible_with (below) is the runtime truth -- it also checks

--- a/processors/conversion/extract_urls.py
+++ b/processors/conversion/extract_urls.py
@@ -13,6 +13,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Stijn Peeters", "Dale Wahl", "Sal Hagen"]
@@ -31,6 +32,8 @@ class ExtractURLs(BasicProcessor):
     title = "Extract and expand URLs"  # title displayed in UI
     description = "Extract any URLs from selected column(s) with the option to expand shortened URLs."
     extension = "csv"
+    # a derived table
+    output = Table()
     icon = "globe"
 
     # any csv/ndjson dataset, except this processor's own filter output

--- a/processors/conversion/hash_images.py
+++ b/processors/conversion/hash_images.py
@@ -34,7 +34,7 @@ class ImageHasher(BasicProcessor):
     icon = ""
 
     # image datasets: image archives, image-downloader output, or extracted video frames
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"})
 
     references = [
         "[Imagehash library](https://github.com/JohannesBuchner/imagehash?tab=readme-ov-file)",

--- a/processors/conversion/hash_images.py
+++ b/processors/conversion/hash_images.py
@@ -10,6 +10,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput, hash_image, stringify_hash
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from processors.metrics.group_hashes import HashGrouper
 
 
@@ -28,6 +29,8 @@ class ImageHasher(BasicProcessor):
     title = "Hash images"  # title displayed in UI
     description = "Convert images to text hashes for comparison and similarity detection."  # description displayed in UI
     extension = "csv"
+    # a derived table
+    output = Table()
     icon = ""
 
     # image datasets: image archives, image-downloader output, or extracted video frames

--- a/processors/conversion/item_to_annotation.py
+++ b/processors/conversion/item_to_annotation.py
@@ -4,6 +4,7 @@ Change a dataset item to an annotation
 from common.lib.exceptions import ProcessorInterruptedException
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import NoOutput
 from common.lib.helpers import UserInput
 
 __author__ = "Sal Hagen"
@@ -23,6 +24,8 @@ class ItemToAnnotation(BasicProcessor):
     description = ("Convert a regular dataset item to an annotation. This will show it as a separate value in the "
                    "Explorer. Item values must be numbers or strings.")  # description displayed in UI
     extension = "csv"
+    # writes annotations to its parent, no result file of its own
+    output = NoOutput()
     icon = "tags"
 
     # Allow on top-level CSV/NDJSON datasets

--- a/processors/conversion/merge_datasets.py
+++ b/processors/conversion/merge_datasets.py
@@ -10,6 +10,7 @@ from common.lib.exceptions import ProcessorInterruptedException, DataSetExceptio
 from common.lib.helpers import UserInput
 from common.lib.item_mapping import MappedItem
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Filter
 import ural
 
 __author__ = "Stijn Peeters"
@@ -29,6 +30,8 @@ class DatasetMerger(BasicProcessor):
     title = "Merge datasets"  # title displayed in UI
     description = "Merge this dataset with other datasets of the same format. A new dataset is " \
                   "created containing a combination of items from the original datasets."  # description displayed in UI
+    # keeps the (primary parent's) shape; the merged datasets share its format
+    output = Filter()
     icon = "arrows-to-dot"
 
     # a collector's csv or ndjson output

--- a/processors/conversion/ndjson_to_csv.py
+++ b/processors/conversion/ndjson_to_csv.py
@@ -7,6 +7,7 @@ import json
 from common.lib.helpers import flatten_dict
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 
 __author__ = "Dale Wahl"
@@ -26,6 +27,8 @@ class ConvertNDJSONtoCSV(BasicProcessor):
 	description = "Create a CSV file from an NDJSON file. Note that some data may be lost as CSV files cannot " \
 				  "contain nested data."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a derived table
+	output = Table()
 	icon = "file-csv"
 
 	# Allow on NDJSON datasets

--- a/processors/conversion/remove_author_info.py
+++ b/processors/conversion/remove_author_info.py
@@ -11,6 +11,7 @@ import csv
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Filter
 from common.lib.helpers import dict_search_and_update, UserInput, HashCache
 
 __author__ = "Stijn Peeters"
@@ -28,6 +29,8 @@ class AuthorInfoRemover(BasicProcessor):
     type = "author-info-remover"  # job type ID
     category = "Conversion"  # category
     filter = True  # to indicate we're filtering the top dataset
+    # keeps the parent's shape, with personal-information fields removed or replaced
+    output = Filter()
     title = "Pseudonymise or anonymise"  # title displayed in UI
     description = "Removes or replaces data from the dataset in fields identified as containing personal information"
     icon = "user-secret"

--- a/processors/conversion/split_by_thread.py
+++ b/processors/conversion/split_by_thread.py
@@ -5,6 +5,7 @@ import csv
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Archive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -26,6 +27,9 @@ class ThreadSplitter(BasicProcessor):
 	description = "Split the dataset per thread. The result is a ZIP archive containing separate CSV files."  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
 	icon = "scissors"
+
+	# a zip archive of data files
+	output = Archive()
 
 	# datasets with a thread structure (4chan/8chan, reddit, breitbart)
 	compatibility = Compatibility(datasources={"fourchan", "eightchan", "reddit", "breitbart"})

--- a/processors/conversion/stringify.py
+++ b/processors/conversion/stringify.py
@@ -6,6 +6,7 @@ import string
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import File
 from common.lib.helpers import UserInput
 
 __author__ = "Sal Hagen"
@@ -22,6 +23,8 @@ class Stringify(BasicProcessor):
 	title = "Merge texts"  # title displayed in UI
 	description = "Merges the data from the body column into a single text file. The result can be used for word clouds, word trees, etc."  # description displayed in UI
 	extension = "txt"  # extension of result file, used internally and in UI
+	# a single txt file
+	output = File("txt")
 	icon = "file-lines"
 
 	# Allow on top-level CSV/NDJSON datasets

--- a/processors/conversion/tcat_auto_upload.py
+++ b/processors/conversion/tcat_auto_upload.py
@@ -10,6 +10,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.user_input import UserInput
 from common.lib.helpers import get_last_line
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import File
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl", "Stijn Peeters"]
@@ -27,6 +28,8 @@ class FourcatToDmiTcatUploader(BasicProcessor):
     title = "Upload to DMI-TCAT"  # title displayed in UI
     description = "Send a TCAT-ready JSON file to a particular DMI-TCAT server."  # description displayed in UI
     extension = "html"  # extension of result file, used internally and in UI
+    # a single html file
+    output = File("html")
     icon = "brand-twitter"
 
     # the TCAT converter's output, when a TCAT server is configured

--- a/processors/conversion/twitter_ndjson_to_tcat_json.py
+++ b/processors/conversion/twitter_ndjson_to_tcat_json.py
@@ -5,6 +5,7 @@ import json
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import File
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -20,6 +21,8 @@ class ConvertNDJSONToJSON(BasicProcessor):
     title = "Convert to TCAT JSON"  # title displayed in UI
     description = "Convert a Twitter dataset to a TCAT-compatible format. This file can then be uploaded to TCAT."  # description displayed in UI
     extension = "json"  # extension of result file, used internally and in UI
+    # a single json file
+    output = File("json")
     icon = "square-js"
 
     # Allow processor on Twitter/X (API v2) datasets

--- a/processors/conversion/upload_annotations.py
+++ b/processors/conversion/upload_annotations.py
@@ -8,6 +8,7 @@ from flask import g
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException, QueryParametersException, DataSetException
 from common.lib.helpers import UserInput
 from common.lib.dataset import DataSet
@@ -29,6 +30,8 @@ class UploadAnnotations(BasicProcessor):
 				   "The first column should contain item IDs; subsequent columns become annotation fields. "
 				   "For CSV file uploads, comma is used as the separator. For text input, a custom separator can be specified.")
 	extension = "csv"
+	# a derived table
+	output = Table()
 	icon = "tags"
 
 	# Allow on top-level CSV/NDJSON datasets

--- a/processors/conversion/view_metadata.py
+++ b/processors/conversion/view_metadata.py
@@ -8,6 +8,7 @@ import zipfile
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.user_input import UserInput
 
 __author__ = "Dale Wahl"
@@ -27,6 +28,8 @@ class ViewMetadata(BasicProcessor):
 	title = "View media metadata"  # title displayed in UI
 	description = "Reformats the .metadata.json file and calculates analytics"  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a derived table
+	output = Table()
 	icon = "circle-info"
 
 	# Allow on downloaded media datasets

--- a/processors/conversion/vision_api_to_csv.py
+++ b/processors/conversion/vision_api_to_csv.py
@@ -5,6 +5,7 @@ import csv
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.helpers import UserInput
 
 __author__ = "Stijn Peeters"
@@ -29,6 +30,8 @@ class ConvertVisionOutputToCSV(BasicProcessor):
     description = ("Convert the Vision API output to a simplified CSV file. Also allows writing results as annotations "
                    "to the original dataset.")  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
     icon = "file-csv"
 
     # Allow processor on Google Vision API output

--- a/processors/filtering/accent_fold.py
+++ b/processors/filtering/accent_fold.py
@@ -7,6 +7,7 @@ import csv
 from unidecode import unidecode
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Output, PASSTHROUGH
 from common.lib.helpers import UserInput
 
 __author__ = "Stijn Peeters"
@@ -27,6 +28,10 @@ class AccentFoldingFilter(BasicProcessor):
     description = ("Replaces or transliterates non-Latin characters with the closest ASCII equivalent, converting e.g. "
                    "'á' to 'a', 'ç' to 'c', etc. This creates a new dataset.")
     extension = "csv"  # extension of result file, used internally and in UI
+    # writes a new csv keeping the parent's columns; made standalone, so its position
+    # and collector-ness take on the original dataset's and are unknown here
+    output = Output(extension="csv", columns=PASSTHROUGH, position=None, collector=None,
+                    datasource=PASSTHROUGH)
     icon = "language"
 
     # Allow on top-level CSV datasets

--- a/processors/filtering/base_filter.py
+++ b/processors/filtering/base_filter.py
@@ -7,6 +7,7 @@ import json
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Filter
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -27,6 +28,10 @@ class BaseFilter(BasicProcessor):
     icon = "filter"
 
     item_ids = []
+
+    # A filter re-emits its parent's rows, so its extension, media and columns are
+    # the parent's. Subclasses keep this; one that adds a column declares its own.
+    output = Filter()
 
     # Abstract base filter; not runnable on its own (empty type set never matches)
     compatibility = Compatibility(types=set())

--- a/processors/filtering/tiktok_refresh.py
+++ b/processors/filtering/tiktok_refresh.py
@@ -7,6 +7,7 @@ import json
 from datasources.tiktok_urls.search_tiktok_urls import TikTokScraper
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Output, PASSTHROUGH
 
 
 __author__ = "Dale Wahl"
@@ -21,6 +22,10 @@ class UpdateTikTok(BasicProcessor):
     title = "Recollect TikTok data"  # title displayed in UI
     description = "Re-query TikTok URLs to update the dataset, e.g. to refresh video URLs or like counts."
     extension = "ndjson"
+    # re-collects the parent's TikTok data as ndjson; made standalone and adopts the
+    # collector's type, so its position and collector-ness are unknown here
+    output = Output(extension="ndjson", columns=PASSTHROUGH, position=None, collector=None,
+                    datasource=PASSTHROUGH)
     icon = "brand-tiktok"
 
     # Allow processor on TikTok datasets

--- a/processors/filtering/unique_images.py
+++ b/processors/filtering/unique_images.py
@@ -30,7 +30,7 @@ class UniqueImageFilter(BasicProcessor):
     output = MediaArchive(media="image")
 
     # image datasets: image archives, image-downloader output, or extracted video frames
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"})
 
     references = [
         "[Imagehash library](https://github.com/JohannesBuchner/imagehash?tab=readme-ov-file)",

--- a/processors/filtering/unique_images.py
+++ b/processors/filtering/unique_images.py
@@ -8,6 +8,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput, hash_file
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -24,6 +25,9 @@ class UniqueImageFilter(BasicProcessor):
     title = "Filter for unique images"  # title displayed in UI
     description = "Only keeps one instance per image using various detection methods."  # description displayed in UI
     extension = "zip"
+    media_type = "image"  # the retained files are images; set so the map and runtime agree
+    # a zip archive of image files
+    output = MediaArchive(media="image")
 
     # image datasets: image archives, image-downloader output, or extracted video frames
     compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"})

--- a/processors/machine_learning/audio_to_text.py
+++ b/processors/machine_learning/audio_to_text.py
@@ -35,7 +35,7 @@ class AudioToText(BasicProcessor):
     icon = "closed-captioning"
 
     # Allow on audio datasets
-    compatibility = Compatibility(media_types={"audio"}, type_prefixes={"audio-extractor"})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"audio"}, type_prefixes={"audio-extractor"})
 
     references = [
         "[OpenAI Whisper blog](https://openai.com/research/whisper)",

--- a/processors/machine_learning/audio_to_text.py
+++ b/processors/machine_learning/audio_to_text.py
@@ -8,6 +8,7 @@ from requests.exceptions import ConnectionError
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.dmi_service_manager import DmiServiceManager, DmiServiceManagerException, DsmOutOfMemory
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
@@ -29,6 +30,8 @@ class AudioToText(BasicProcessor):
     description = ("Detect speech and other sounds in audio and convert to text with either OpenAI's Whisper or "
                    " GPT models (GPT only via API).")  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table(extension="ndjson")
     icon = "closed-captioning"
 
     # Allow on audio datasets

--- a/processors/machine_learning/blip2_image_caption.py
+++ b/processors/machine_learning/blip2_image_caption.py
@@ -10,6 +10,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 from common.lib.item_mapping import MappedItem
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -26,6 +27,8 @@ class CategorizeImagesCLIP(BasicProcessor):
     title = "Generate image captions using OpenAI's BLIP2 model"  # title displayed in UI
     description = "The BLIP2 model uses a pretrained image encoder combined with an LLM to generate image captions. The model can also be prompted and uses the image plus prompt to generate text responses."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table(extension="ndjson")
     icon = "eye"
 
     # image datasets (image archives or image-downloader output), when BLIP2 is enabled

--- a/processors/machine_learning/blip2_image_caption.py
+++ b/processors/machine_learning/blip2_image_caption.py
@@ -32,7 +32,7 @@ class CategorizeImagesCLIP(BasicProcessor):
     icon = "eye"
 
     # image datasets (image archives or image-downloader output), when BLIP2 is enabled
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.fc_blip2_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-text-wall"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.fc_blip2_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-text-wall"])
 
     references = [
         "[OpenAI CLIP blog](https://openai.com/research/clip)",

--- a/processors/machine_learning/clarifai_api.py
+++ b/processors/machine_learning/clarifai_api.py
@@ -11,6 +11,7 @@ from clarifai_grpc.channel.clarifai_channel import ClarifaiChannel
 from common.lib.helpers import UserInput, convert_to_int
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -33,6 +34,8 @@ class ClarifaiAPIFetcher(BasicProcessor):
                   "One request will be made per image per annotation type. Note that this is NOT a free service and " \
                   "requests will be credited by Clarifai to the owner of the API token you provide."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table(extension="ndjson")
     icon = "eye"
 
     # Allow on image sets

--- a/processors/machine_learning/clarifai_api.py
+++ b/processors/machine_learning/clarifai_api.py
@@ -39,7 +39,7 @@ class ClarifaiAPIFetcher(BasicProcessor):
     icon = "eye"
 
     # Allow on image sets
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, preferred_followups=["convert-clarifai-vision-to-csv", "clarifai-bipartite-network"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, preferred_followups=["convert-clarifai-vision-to-csv", "clarifai-bipartite-network"])
 
     references = [
         "[Clarifai](https://www.clarifai.com/)",

--- a/processors/machine_learning/clip_categorize_images.py
+++ b/processors/machine_learning/clip_categorize_images.py
@@ -11,6 +11,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 from common.lib.item_mapping import MappedItem
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -29,6 +30,9 @@ class CategorizeImagesCLIP(BasicProcessor):
                    "the likelihood an image belongs to a category (total of all category values will be 100%).")  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
     icon = "eye"
+
+    # a derived table
+    output = Table(extension="ndjson")
 
     # image datasets (image archives or image-downloader output), when CLIP is enabled
     compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.cc_clip_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-category-wall"])

--- a/processors/machine_learning/clip_categorize_images.py
+++ b/processors/machine_learning/clip_categorize_images.py
@@ -35,7 +35,7 @@ class CategorizeImagesCLIP(BasicProcessor):
     output = Table(extension="ndjson")
 
     # image datasets (image archives or image-downloader output), when CLIP is enabled
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.cc_clip_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-category-wall"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.cc_clip_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-category-wall"])
 
     references = [
         "[OpenAI CLIP blog](https://openai.com/research/clip)",

--- a/processors/machine_learning/generate_images.py
+++ b/processors/machine_learning/generate_images.py
@@ -12,6 +12,7 @@ from processors.visualisation.download_images import ImageDownloader
 from common.lib.dmi_service_manager import DmiServiceManager, DmiServiceManagerException, DsmOutOfMemory
 from common.lib.user_input import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -28,6 +29,9 @@ class StableDiffusionImageGenerator(BasicProcessor):
     title = "Generate images from text prompts"  # title displayed in UI
     description = "Given a list of prompts, generates images using the Stable Diffusion XL image model."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
+    media_type = "image"  # the generated files are images; set so the map and runtime agree
+    # a zip archive of image files
+    output = MediaArchive(media="image")
     icon = "images"
 
     # coarse map spec; is_compatible_with (below) is the runtime truth -- it also requires the

--- a/processors/machine_learning/google_vision_api.py
+++ b/processors/machine_learning/google_vision_api.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from common.lib.helpers import UserInput, convert_to_int
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 
 __author__ = "Stijn Peeters"
@@ -36,6 +37,9 @@ class GoogleVisionAPIFetcher(BasicProcessor):
                   "and Google Vision API enabled (this may take a few minutes)."  # description displayed in UI
     extension = "ndjson"  # extension of result file, used internally and in UI
     icon = "eye"
+
+    # a derived table
+    output = Table(extension="ndjson")
 
     # Allow on image sets
     compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, preferred_followups=["convert-google-vision-to-csv", "vision-bipartite-network", "vision-label-network"])

--- a/processors/machine_learning/google_vision_api.py
+++ b/processors/machine_learning/google_vision_api.py
@@ -42,7 +42,7 @@ class GoogleVisionAPIFetcher(BasicProcessor):
     output = Table(extension="ndjson")
 
     # Allow on image sets
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, preferred_followups=["convert-google-vision-to-csv", "vision-bipartite-network", "vision-label-network"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, preferred_followups=["convert-google-vision-to-csv", "vision-bipartite-network", "vision-label-network"])
 
     references = [
         "[Google Vision API Documentation](https://cloud.google.com/vision/docs)",

--- a/processors/machine_learning/llm_prompter.py
+++ b/processors/machine_learning/llm_prompter.py
@@ -21,6 +21,7 @@ from common.lib.helpers import UserInput, nthify, andify, remove_nuls, flatten_d
 from common.lib.llm.adapter import LLMAdapter
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 class LLMPrompter(BasicProcessor):
     """
@@ -33,6 +34,9 @@ class LLMPrompter(BasicProcessor):
                    "entity extraction, or OCR. Supported APIs include OpenAI, Google, Anthropic, Mistral, and DeepSeek.")
     extension = "ndjson"  # extension of result file, used internally and in UI. In this case it's variable!
     icon = "robot"
+
+    # a derived table
+    output = Table(extension="ndjson")
 
     # coarse map spec; is_compatible_with (below) is the runtime truth -- it accepts csv/ndjson
     # tables, OR zip archives of image/video/audio media (_almost_ all zips but not)

--- a/processors/machine_learning/perspective.py
+++ b/processors/machine_learning/perspective.py
@@ -10,6 +10,7 @@ from backend.lib.processor import BasicProcessor
 from googleapiclient import discovery
 from common.lib.item_mapping import MappedItem
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 class Perspective(BasicProcessor):
 	"""
@@ -22,6 +23,9 @@ class Perspective(BasicProcessor):
 					"including 'toxicity', 'insult', and 'profanity'.")		# description displayed in UI
 	extension = "ndjson"  # extension of result file, used internally and in UI
 	icon = "hand-middle-finger"
+
+	# a derived table
+	output = Table(extension="ndjson")
 
 	# top-level text datasets (scores text columns via the Perspective API)
 	compatibility = Compatibility(top_dataset_only=True, extensions={"csv", "ndjson"})

--- a/processors/machine_learning/pix-plot.py
+++ b/processors/machine_learning/pix-plot.py
@@ -14,6 +14,7 @@ from common.lib.dmi_service_manager import DmiServiceManager, DsmOutOfMemory, Dm
 from common.lib.helpers import UserInput, ellipsiate
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import File
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -33,6 +34,8 @@ class PixPlotGenerator(BasicProcessor):
     description = "Put all images from an archive into a PixPlot visualisation: an explorable map of images " \
                   "algorithmically grouped by similarity."
     extension = "html"  # extension of result file, used internally and in UI
+    # a single html file
+    output = File("html")
     icon = "images"
 
     # image datasets (image archives or image-downloader output), when PixPlot is enabled

--- a/processors/machine_learning/pix-plot.py
+++ b/processors/machine_learning/pix-plot.py
@@ -39,7 +39,7 @@ class PixPlotGenerator(BasicProcessor):
     icon = "images"
 
     # image datasets (image archives or image-downloader output), when PixPlot is enabled
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.db_pixplot_enabled", "dmi-service-manager.ab_server_address"})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.db_pixplot_enabled", "dmi-service-manager.ab_server_address"})
 
     references = [
         "[PixPlot](https://pixplot.io/)",

--- a/processors/machine_learning/text_from_image.py
+++ b/processors/machine_learning/text_from_image.py
@@ -43,7 +43,7 @@ class ImageTextDetector(BasicProcessor):
     icon = "language"
 
     # image datasets (image archives or image-downloader output), when the OCR server is enabled
-    compatibility = Compatibility(media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.eb_ocr_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-text-wall"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"image"}, type_prefixes={"image-downloader"}, required_settings={"dmi-service-manager.eb_ocr_enabled", "dmi-service-manager.ab_server_address"}, preferred_followups=["image-text-wall"])
 
     references = [
         "[DMI OCR Server](https://github.com/digitalmethodsinitiative/ocr_server#readme)",

--- a/processors/machine_learning/text_from_image.py
+++ b/processors/machine_learning/text_from_image.py
@@ -14,6 +14,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.item_mapping import MappedItem
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -37,6 +38,8 @@ class ImageTextDetector(BasicProcessor):
     sort them into likely groupings based on locations within the original image.
     """
     extension = "ndjson"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table(extension="ndjson")
     icon = "language"
 
     # image datasets (image archives or image-downloader output), when the OCR server is enabled

--- a/processors/metrics/annotation_metadata.py
+++ b/processors/metrics/annotation_metadata.py
@@ -4,6 +4,7 @@ Retrieves metadata on annotations for this dataset.
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 from datetime import datetime
 
@@ -17,6 +18,8 @@ class AnnotationMetadata(BasicProcessor):
 	description = ("Download annotations and their metadata for this dataset. "
 				   "Includes annotation author, timestamp, type, etc.") # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a derived table
+	output = Table()
 	icon = "circle-info"
 
 	# coarse map spec (accepts any dataset); is_compatible_with (below) is the runtime

--- a/processors/metrics/count_posts.py
+++ b/processors/metrics/count_posts.py
@@ -5,6 +5,7 @@ Collapse post bodies into one long string
 from common.lib.helpers import UserInput, pad_interval, get_interval_descriptor
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -21,6 +22,8 @@ class CountPosts(BasicProcessor):
     title = "Count items per date"  # title displayed in UI
     description = "Counts how many items are in the dataset per date (or overall)."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a ranking table (date/item/value), so ranking visualisations can run on it
+    output = Table(columns={"date", "item", "value"})
     icon = "list-ol"
 
     # Allow on top-level CSV/NDJSON datasets

--- a/processors/metrics/debate_metrics.py
+++ b/processors/metrics/debate_metrics.py
@@ -6,6 +6,7 @@ import time
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Sal Hagen"
 __credits__ = ["Sal Hagen"]
@@ -31,6 +32,9 @@ class DebateMetrics(BasicProcessor):
 	description = "Returns a csv with meta-metrics per thread."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
 	icon = "circle-info"
+
+	# a derived table
+	output = Table()
 
 	# chan datasets (thread-level debate metrics)
 	compatibility = Compatibility(datasources={"fourchan", "eightchan", "eightkun"})

--- a/processors/metrics/group_hashes.py
+++ b/processors/metrics/group_hashes.py
@@ -4,6 +4,7 @@ import imagehash
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput, normalize_crhash_components
 
@@ -21,6 +22,8 @@ class HashGrouper(BasicProcessor):
     title = "Group similar hashes"  # title displayed in UI
     description = "Calculate groups of similar hashes from a CSV file."  # description displayed in UI
     extension = "csv"
+    # a derived table
+    output = Table()
     icon = "hashtag"
 
     # Allow processor on image-hasher output (could also work on any CSV with the right fields)

--- a/processors/metrics/most_quoted.py
+++ b/processors/metrics/most_quoted.py
@@ -6,6 +6,7 @@ import re
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -23,6 +24,8 @@ class QuoteRanker(BasicProcessor):
 	title = "Sort by most replied-to"  # title displayed in UI
 	description = "Sort posts by how often they were replied to by other posts in the dataset."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a derived table
+	output = Table()
 	icon = "comments"
 
 	# chan datasets (posts reply to / quote each other)

--- a/processors/metrics/rank_attribute.py
+++ b/processors/metrics/rank_attribute.py
@@ -9,6 +9,7 @@ from itertools import islice, chain
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.helpers import UserInput, convert_to_int, get_interval_descriptor
 
 __author__ = "Stijn Peeters"
@@ -30,6 +31,8 @@ class AttributeRanker(BasicProcessor):
     title = "Count values"  # title displayed in UI
     description = "Count values in a dataset column, like URLs or hashtags (overall or per timeframe)"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a ranking table (date/item/value), so ranking visualisations can run on it
+    output = Table(columns={"date", "item", "value"})
     icon = "list-ol"
 
     # Allow on CSV/NDJSON datasets

--- a/processors/metrics/thread_metadata.py
+++ b/processors/metrics/thread_metadata.py
@@ -6,6 +6,7 @@ import math
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Sal Hagen"
 __credits__ = ["Sal Hagen"]
@@ -26,6 +27,9 @@ class ThreadMetadata(BasicProcessor):
     )  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
     icon = "circle-info"
+
+    # a derived table
+    output = Table()
 
     # Allow on top-level CSV/NDJSON datasets
     compatibility = Compatibility(top_dataset_only=True, extensions={"csv", "ndjson"})

--- a/processors/metrics/top_images.py
+++ b/processors/metrics/top_images.py
@@ -7,6 +7,7 @@ from collections import Counter, OrderedDict
 from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -25,6 +26,8 @@ class TopImageCounter(BasicProcessor):
     title = "Rank image URLs"  # title displayed in UI
     description = "Collect all image URLs and sort by most-occurring."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a ranking table (date/item/value), so ranking visualisations can run on it
+    output = Table(columns={"date", "item", "value"})
     icon = "arrow-up-1-9"
 
     # top-level csv/ndjson datasets, except Telegram (which has its own image logic)

--- a/processors/metrics/url_titles.py
+++ b/processors/metrics/url_titles.py
@@ -5,6 +5,7 @@ import csv
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from backend.lib.proxied_requests import FailedProxiedRequest
 from common.lib.helpers import UserInput
 from common.lib.exceptions import ProcessorInterruptedException
@@ -31,6 +32,8 @@ class URLFetcher(BasicProcessor):
     description = ("Fetches the page title and other metadata for URLs referenced in the dataset. Makes a request to "
                    "each URL, optionally following HTTP redirects.")  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
     icon = "globe"
 
     # Allow on top-level CSV/NDJSON datasets

--- a/processors/metrics/vocabulary_overtime.py
+++ b/processors/metrics/vocabulary_overtime.py
@@ -5,6 +5,7 @@ import re
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.helpers import UserInput, get_interval_descriptor
 
 __author__ = "Stijn Peeters"
@@ -22,6 +23,8 @@ class OvertimeAnalysis(BasicProcessor):
     title = "Over-time word counts"  # title displayed in UI
     description = "Determines the counts over time of particular set of words or phrases."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a ranking table (date/item/value), so ranking visualisations can run on it
+    output = Table(columns={"date", "item", "value"})
     icon = "chart-line"
 
     # Allow on top-level CSV/NDJSON datasets

--- a/processors/metrics/youtube_metadata.py
+++ b/processors/metrics/youtube_metadata.py
@@ -12,6 +12,7 @@ from googleapiclient.errors import HttpError
 from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Sal Hagen"
 __credits__ = ["Sal Hagen"]
@@ -36,6 +37,8 @@ class YouTubeMetadata(BasicProcessor):
 	description = ("Collect metadata from YouTube videos, channels, and playlists that are linked to in the dataset. "
 				   "Uses the YouTube API.")  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a derived table
+	output = Table()
 	icon = "brand-youtube"
 
 	# collector output or extract-urls-filter output, as csv/ndjson (may contain youtube links)

--- a/processors/networks/clarifai_bipartite_network.py
+++ b/processors/networks/clarifai_bipartite_network.py
@@ -3,6 +3,7 @@ Google Vision API co-label network
 """
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.helpers import UserInput
 
 __author__ = "Stijn Peeters"
@@ -24,6 +25,8 @@ class VisionTagBiPartiteNetworker(BasicProcessor):
                   "returned by the API, and image file names, are nodes. Edges are created between file names and " \
                   "labels if the label occurs for the image with that file name."
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a graph file, no column table
+    output = Network()
     icon = "circle-nodes"
 
     # Allow processor to run on Clarifai API data

--- a/processors/networks/colink_urls.py
+++ b/processors/networks/colink_urls.py
@@ -9,6 +9,7 @@ import psutil
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput
 
@@ -33,6 +34,8 @@ class URLCoLinker(BasicProcessor):
 	description = "Create a GEXF network file comprised of URLs appearing together (in a post or thread). " \
 				  "Edges are weighted by amount of co-links."  # description displayed in UI
 	extension = "gexf"  # extension of result file, used internally and in UI
+	# a graph file, no column table
+	output = Network()
 	icon = "circle-nodes"
 
 	# Allow on top-level CSV/NDJSON datasets

--- a/processors/networks/cotag_network.py
+++ b/processors/networks/cotag_network.py
@@ -5,6 +5,7 @@ Generate co-tag network of co-occurring (hash)tags in items
 from backend.lib.preset import ProcessorPreset
 from common.lib.helpers import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -23,6 +24,8 @@ class CoTaggerPreset(ProcessorPreset):
                   "Edges are weighted by the amount of tag co-occurrences; nodes " \
                   "are weighted by how often the tag appears in the dataset."  # description displayed in UI
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a preset; its output is its last step's
+    output = Delegated()
     icon = "circle-nodes"
 
 

--- a/processors/networks/coword_network.py
+++ b/processors/networks/coword_network.py
@@ -4,6 +4,7 @@ Generate co-word network of word collocations
 
 from backend.lib.preset import ProcessorPreset
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 __author__ = "Sal Hagen"
 __credits__ = ["Sal Hagen"]
@@ -23,6 +24,9 @@ class CowordNetworker(ProcessorPreset):
                   "amount of co-word occurrences."  # description displayed in UI
     extension = "gexf"  # extension of result file, used internally and in UI
     icon = "circle-nodes"
+
+    # a preset; its output is its last step's
+    output = Delegated()
 
     # Allow processor to run on collocations
     compatibility = Compatibility(types={"collocations"})

--- a/processors/networks/gexf_to_csv.py
+++ b/processors/networks/gexf_to_csv.py
@@ -3,6 +3,7 @@ Convert a GEXF network file to a CSV file
 """
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 import networkx as nx
 import csv
@@ -23,6 +24,8 @@ class GexfToCsv(BasicProcessor):
     title = "Export Network as CSV Spreadsheet"
     description = "Convert a GEXF network file to a CSV spreadsheet"
     extension = "csv"
+    # a derived table
+    output = Table()
     icon = "file-csv"
 
     # Allow on GEXF datasets

--- a/processors/networks/google_vision_bipartite_network.py
+++ b/processors/networks/google_vision_bipartite_network.py
@@ -3,6 +3,7 @@ Google Vision API co-label network
 """
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.helpers import UserInput
 from common.lib.exceptions import ProcessorInterruptedException
 
@@ -25,6 +26,8 @@ class VisionTagBiPartiteNetworker(BasicProcessor):
                   "returned by the API, and image file names, are nodes. Edges are created between file names and " \
                   "labels if the label occurs for the image with that file name."
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a graph file, no column table
+    output = Network()
     icon = "circle-nodes"
 
     # Allow processor to run on Google Vision API data

--- a/processors/networks/google_vision_network.py
+++ b/processors/networks/google_vision_network.py
@@ -3,6 +3,7 @@ Google Vision API co-label network
 """
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.helpers import UserInput
 from common.lib.exceptions import ProcessorInterruptedException
 
@@ -25,6 +26,8 @@ class VisionTagNetworker(BasicProcessor):
                   "Google Vision API. Labels returned by the API are nodes. Labels occurring on the same image form" \
                   "edges."
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a graph file, no column table
+    output = Network()
     icon = "circle-nodes"
 
     # Allow processor to run on Google Vision API data

--- a/processors/networks/hash_similarity_network.py
+++ b/processors/networks/hash_similarity_network.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.exceptions import ProcessorException
 from common.lib.helpers import UserInput
 
@@ -27,6 +28,8 @@ class HashSimilarityNetworker(BasicProcessor):
     title = "Hash similarity network"
     description = "Calculate similarity of hashes and create a GEXF network file. Can identify near duplicate hashes."
     extension = "gexf"
+    # a graph file, no column table
+    output = Network()
     icon = "circle-nodes"
 
     # Currently only allowed on video-hashes, though any row of bit hashes would work.

--- a/processors/networks/hash_similarity_network.py
+++ b/processors/networks/hash_similarity_network.py
@@ -32,8 +32,9 @@ class HashSimilarityNetworker(BasicProcessor):
     output = Network()
     icon = "circle-nodes"
 
-    # Currently only allowed on video-hashes, though any row of bit hashes would work.
-    compatibility = Compatibility(types={"video-hashes"})
+    # Runs on the video hasher's output (like the other video-hash networks); any
+    # dataset of bit-hash rows would work.
+    compatibility = Compatibility(types={"video-hasher-1"})
 
     @classmethod
     def get_options(cls, parent_dataset=None, config=None):

--- a/processors/networks/image-network.py
+++ b/processors/networks/image-network.py
@@ -16,6 +16,7 @@ __email__ = "4cat@oilab.eu"
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 
 
 class ImageGrapher(BasicProcessor):
@@ -33,6 +34,8 @@ class ImageGrapher(BasicProcessor):
                    "the images were sourced from. Suitable for use with Gephi's "
                    "'Image Preview' plugin.")
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a graph file, no column table
+    output = Network()
     icon = "circle-nodes"
 
     # coarse map spec; is_compatible_with (below) is the runtime truth -- it also walks the

--- a/processors/networks/quote_network.py
+++ b/processors/networks/quote_network.py
@@ -5,6 +5,7 @@ import re
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 
 import networkx as nx
 
@@ -25,6 +26,8 @@ class QuoteNetworkGrapher(BasicProcessor):
 	description = "Create a GEXF network file of posts replying to each other. " \
 				  "Each reference to another post creates an edge between posts. "  # description displayed in UI
 	extension = "gexf"  # extension of result file, used internally and in UI
+	# a graph file, no column table
+	output = Network()
 	icon = "circle-nodes"
 
 	# chan datasets (posts reply to / quote each other)

--- a/processors/networks/two-column-network.py
+++ b/processors/networks/two-column-network.py
@@ -6,6 +6,7 @@ from functools import partial
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.helpers import UserInput, get_interval_descriptor
 
 import networkx as nx
@@ -27,6 +28,8 @@ class ColumnNetworker(BasicProcessor):
     description = "Create a GEXF network file comprised of linked values between a custom set of columns " \
                   "(e.g. 'author' and 'subreddit'). Nodes and edges are weighted by frequency."
     extension = "gexf"
+    # a graph file, no column table
+    output = Network()
     icon = "circle-nodes"
 
     # Allow on CSV/NDJSON datasets

--- a/processors/networks/user_hashtag_network.py
+++ b/processors/networks/user_hashtag_network.py
@@ -4,6 +4,7 @@ Generate bipartite user-hashtag graph of posts
 from backend.lib.preset import ProcessorPreset
 from common.lib.user_input import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 
 __author__ = "Stijn Peeters"
@@ -21,6 +22,8 @@ class HashtagUserBipartiteGrapherPreset(ProcessorPreset):
     title = "Author-tag Network"  # title displayed in UI
     description = "Produces a bipartite graph based on co-occurence of (hash)tags and authors. If someone wrote a post with a certain tag, there will be a link between that person and the tag. The more often they appear together, the stronger the link. Tag nodes are weighed on how often they occur. User nodes are weighed on how many posts they've made."  # description displayed in UI
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a preset; its output is its last step's
+    output = Delegated()
     icon = "circle-nodes"
 
     # datasets with at least one tag-like column

--- a/processors/networks/wikipedia_network.py
+++ b/processors/networks/wikipedia_network.py
@@ -10,6 +10,7 @@ import networkx as nx
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Network
 from common.lib.exceptions import ProcessorInterruptedException
 
 __author__ = "Stijn Peeters"
@@ -27,6 +28,8 @@ class WikiURLCoLinker(BasicProcessor):
 	title = "Wikipedia category network"  # title displayed in UI
 	description = "Create a GEXF network file comprised network comprised of linked-to Wikipedia pages, linked to the categories they are part of. English Wikipedia only. Will only fetch the first 10,000 links."  # description displayed in UI
 	extension = "gexf"  # extension of result file, used internally and in UI
+	# a graph file, no column table
+	output = Network()
 	icon = "circle-nodes"
 
 	# Allow on top-level CSV/NDJSON datasets

--- a/processors/presets/annotate-images.py
+++ b/processors/presets/annotate-images.py
@@ -3,6 +3,7 @@ Annotate top images
 """
 from backend.lib.preset import ProcessorPreset
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 from common.lib.helpers import UserInput, convert_to_int
 
@@ -17,6 +18,8 @@ class AnnotateImages(ProcessorPreset):
     description = "Use the Google Vision API to extract labels detected in the most-linked images from the dataset. Note that " \
                   "this is a paid service and will count towards your API credit."
     extension = "csv"
+    # a preset; its output is its last step's
+    output = Delegated()
     icon = "tags"
 
     # Allow on top-level CSV/NDJSON datasets

--- a/processors/presets/monthly-histogram.py
+++ b/processors/presets/monthly-histogram.py
@@ -3,6 +3,7 @@ Extract neologisms
 """
 from backend.lib.preset import ProcessorPreset
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 from processors.metrics.count_posts import CountPosts
 
 
@@ -16,6 +17,9 @@ class MonthlyHistogramCreator(ProcessorPreset):
 	description = "Create a histogram that shows the number of items over time."  # description displayed in UI
 	extension = "svg"
 	icon = "square-poll-vertical"
+
+	# a preset; its output is its last step's
+	output = Delegated()
 
 	# Allow on top-level CSV/NDJSON datasets
 	compatibility = Compatibility(top_dataset_only=True, extensions={"csv", "ndjson"})

--- a/processors/presets/neologisms.py
+++ b/processors/presets/neologisms.py
@@ -3,6 +3,7 @@ Extract neologisms
 """
 from backend.lib.preset import ProcessorPreset
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 from common.lib.helpers import UserInput
 
@@ -17,6 +18,8 @@ class NeologismExtractor(ProcessorPreset):
     description = ("Retrieve uncommon terms by deleting all words that appears in dictionary lists. Assumes English-"
                    "language data. Uses stopwords-iso as a stopword filter.")
     extension = "csv"
+    # a preset; its output is its last step's
+    output = Delegated()
     icon = "comment-medical"
 
     # Allow on CSV/NDJSON datasets

--- a/processors/presets/similar-words.py
+++ b/processors/presets/similar-words.py
@@ -5,6 +5,7 @@ from nltk.stem.snowball import SnowballStemmer
 
 from backend.lib.preset import ProcessorPreset
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 from common.lib.helpers import UserInput
 
@@ -19,6 +20,8 @@ class SimilarWords(ProcessorPreset):
 	description = ("Create a word2vec model to find words used in a similar context as the queried word(s). Only works "
 				   "with large datasets (e.g. 100,000+ items).")
 	extension = "csv"
+	# a preset; its output is its last step's
+	output = Delegated()
 	icon = "comments"
 
 	# Allow on top-level CSV/NDJSON datasets

--- a/processors/presets/top-hashtags.py
+++ b/processors/presets/top-hashtags.py
@@ -5,6 +5,7 @@ from backend.lib.preset import ProcessorPreset
 from common.lib.helpers import UserInput
 from processors.networks.cotag_network import CoTaggerPreset
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 
 class TopHashtags(ProcessorPreset):
@@ -16,6 +17,8 @@ class TopHashtags(ProcessorPreset):
     title = "Top hashtags"  # title displayed in UI
     description = "Count how often each hashtag occurs in the dataset and sort by this value"
     extension = "csv"
+    # a preset; its output is its last step's
+    output = Delegated()
     icon = "hashtag"
 
     # datasets with at least one tag-like column

--- a/processors/presets/upload-to-dmi-tcat.py
+++ b/processors/presets/upload-to-dmi-tcat.py
@@ -4,6 +4,7 @@ Upload Twitter dataset to DMI-TCAT instance
 from backend.lib.preset import ProcessorPreset
 from common.lib.helpers import UserInput
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Delegated
 
 class FourcatToDmiTcatConverterAndUploader(ProcessorPreset):
     """
@@ -14,6 +15,8 @@ class FourcatToDmiTcatConverterAndUploader(ProcessorPreset):
     title = "Upload to DMI-TCAT"  # title displayed in UI
     description = "Convert the dataset to a TCAT-compatible format and upload it to an available TCAT server."  # description displayed in UI
     extension = "html"
+    # a preset; its output is its last step's
+    output = Delegated()
     icon = "brand-twitter"
 
     # Twitter v2 search results, when a TCAT server is configured

--- a/processors/presets/video-scene-timelines.py
+++ b/processors/presets/video-scene-timelines.py
@@ -4,6 +4,7 @@ Create scene-by-scene timelines
 
 from backend.lib.preset import ProcessorPreset
 from common.lib.compatibility import Compatibility, is_executable
+from common.lib.outputs import Delegated
 
 
 class VideoSceneTimelineCreator(ProcessorPreset):
@@ -18,6 +19,9 @@ class VideoSceneTimelineCreator(ProcessorPreset):
                   "for all videos are then stacked vertically and rendered as a single SVG file."
     extension = "svg"
     icon = "film"
+
+    # a preset; its output is its last step's
+    output = Delegated()
 
     # Allow on video datasets when ffmpeg is available
     compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})

--- a/processors/presets/video-scene-timelines.py
+++ b/processors/presets/video-scene-timelines.py
@@ -24,7 +24,7 @@ class VideoSceneTimelineCreator(ProcessorPreset):
     output = Delegated()
 
     # Allow on video datasets when ffmpeg is available
-    compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
+    compatibility = Compatibility(extension={"zip"},media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
 
     def get_processor_pipeline(self):
         """

--- a/processors/presets/video-scene-timelines.py
+++ b/processors/presets/video-scene-timelines.py
@@ -24,7 +24,7 @@ class VideoSceneTimelineCreator(ProcessorPreset):
     output = Delegated()
 
     # Allow on video datasets when ffmpeg is available
-    compatibility = Compatibility(extension={"zip"},media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
 
     def get_processor_pipeline(self):
         """

--- a/processors/statistics/classification_evaluation.py
+++ b/processors/statistics/classification_evaluation.py
@@ -6,6 +6,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput, andify
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 from sklearn.preprocessing import MultiLabelBinarizer
 from sklearn.metrics import precision_score, recall_score, f1_score, accuracy_score, cohen_kappa_score
@@ -27,6 +28,9 @@ class ClassificationEvaluation(BasicProcessor):
                    "and Cohen's Kappa). Produces overall and per-label metrics. Also supports multi-label values.")
     extension = "csv"  # extension of result file, used internally and in UI
     icon = "table-columns"
+
+    # a derived table
+    output = Table()
 
     # Allow on CSV/NDJSON datasets
     compatibility = Compatibility(extensions={"csv", "ndjson"})

--- a/processors/statistics/confusion_matrix.py
+++ b/processors/statistics/confusion_matrix.py
@@ -5,6 +5,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
 import matplotlib
@@ -25,6 +26,8 @@ class ConfusionMatrix(BasicProcessor):
     title = "Confusion matrix"  # title displayed in UI
     description = "Create a confusion matrix with data from two columns."  # description displayed in UI
     extension = "png"  # extension of result file, used internally and in UI
+    # a rendered image, no column table
+    output = Render("png")
     icon = "table-columns"
 
     # Allow on CSV/NDJSON datasets

--- a/processors/statistics/descriptive_statistics.py
+++ b/processors/statistics/descriptive_statistics.py
@@ -6,6 +6,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 import numpy as np
 
@@ -24,6 +25,8 @@ class DescriptiveStatistics(BasicProcessor):
     title = "Descriptive statistics"  # title displayed in UI
     description = "Calculate descriptive statistics (mean, median, std dev, etc.) for numerical columns."
     extension = "csv"  # extension of result file, used internally in UI
+    # a derived table
+    output = Table()
     icon = "table-columns"
 
     # Allow on CSV/NDJSON datasets

--- a/processors/statistics/regression-evaluation.py
+++ b/processors/statistics/regression-evaluation.py
@@ -6,6 +6,7 @@ from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 import numpy as np
@@ -26,6 +27,9 @@ class RegressionEvaluation(BasicProcessor):
     description = "Calculate regression metrics (MAE, MSE, R2, RMSE) between two numerical columns."
     extension = "csv"  # extension of result file, used internally in UI
     icon = "table-columns"
+
+    # a derived table
+    output = Table()
 
     # Allow on CSV/NDJSON datasets
     compatibility = Compatibility(extensions={"csv", "ndjson"})

--- a/processors/text-analysis/collocations.py
+++ b/processors/text-analysis/collocations.py
@@ -11,6 +11,7 @@ from nltk.collocations import TrigramCollocationFinder, BigramCollocationFinder
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 
 class GetCollocations(BasicProcessor):
@@ -22,6 +23,9 @@ class GetCollocations(BasicProcessor):
 	title = "Extract co-words"  # title displayed in UI
 	description = "Extracts words appearing close to each other from a set of tokens."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+
+	# a derived table
+	output = Table()
 
 	# Allow processor on token sets
 	compatibility = Compatibility(types={"tokenise-posts"}, preferred_followups=["preset-coword-network", "wordcloud"])

--- a/processors/text-analysis/documents_per_topic.py
+++ b/processors/text-analysis/documents_per_topic.py
@@ -4,6 +4,7 @@ Extracts topics per model and top associated words
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 
 import json
@@ -24,6 +25,9 @@ class TopicModelWordExtractor(BasicProcessor):
     title = "Count documents per topic"  # title displayed in UI
     description = "Uses the LDA model to predict to which topic each item or sentence belongs and counts as belonging to whichever topic has the highest probability."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+
+    # a derived table
+    output = Table()
 
     # Allow processor on topic models
     compatibility = Compatibility(types={"topic-modeller"})

--- a/processors/text-analysis/generate_embeddings.py
+++ b/processors/text-analysis/generate_embeddings.py
@@ -11,6 +11,7 @@ from gensim.models.phrases import Phrases, Phraser
 from common.lib.helpers import UserInput, convert_to_int
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Archive
 from common.lib.exceptions import ProcessorInterruptedException
 
 __author__ = "Sal Hagen"
@@ -32,6 +33,9 @@ class GenerateWordEmbeddings(BasicProcessor):
 				  "e.g. exist of 100 numbers). These numeric word representations can be used to extract words with similar contexts. " \
 				  "Note that good models require a lot of data."  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
+
+	# a zip archive of data files
+	output = Archive()
 
 	# Allow processor on token sets
 	compatibility = Compatibility(types={"tokenise-posts"}, preferred_followups=["similar-word2vec", "histwords-vectspace"])

--- a/processors/text-analysis/post_topic_matrix.py
+++ b/processors/text-analysis/post_topic_matrix.py
@@ -5,6 +5,7 @@ Extracts topics per model and top associated words
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 
 import csv
@@ -29,6 +30,8 @@ class TopicModelWordExtractor(BasicProcessor):
                    "(e.g. only the 'body' column), there is one row per post/item, otherwise a post may be represented "
                    "by multiple rows (for each sentence and/or column used).")  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on topic models
     compatibility = Compatibility(types={"topic-modeller"})

--- a/processors/text-analysis/similar_words.py
+++ b/processors/text-analysis/similar_words.py
@@ -8,6 +8,7 @@ from gensim.models import KeyedVectors
 from common.lib.helpers import UserInput, convert_to_int, convert_to_float
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 
 __author__ = "Sal Hagen"
@@ -25,6 +26,8 @@ class SimilarWord2VecWords(BasicProcessor):
 	title = "Extract similar words"  # title displayed in UI
 	description = "Uses a word2vec model to find words used in a similar context"  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a ranking table (date/item/value), so ranking visualisations can run on it
+	output = Table(columns={"date", "item", "value"})
 
 	# Allow processor on word embedding models
 	compatibility = Compatibility(types={"generate-embeddings"}, preferred_followups=["wordcloud"])

--- a/processors/text-analysis/split_sentences.py
+++ b/processors/text-analysis/split_sentences.py
@@ -7,6 +7,7 @@ from nltk.tokenize import sent_tokenize, word_tokenize
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -23,6 +24,9 @@ class SplitSentences(BasicProcessor):
     title = "Split text into sentences"  # title displayed in UI
     description = "Split a body of posts into discrete sentences. Output file has one row per sentence, containing the sentence and item ID."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+
+    # a derived table
+    output = Table()
 
     # Allow on CSV/NDJSON datasets
     compatibility = Compatibility(extensions={"csv", "ndjson"})

--- a/processors/text-analysis/tf_idf.py
+++ b/processors/text-analysis/tf_idf.py
@@ -10,6 +10,7 @@ import itertools
 from common.lib.helpers import UserInput, convert_to_int
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 from sklearn.feature_extraction.text import TfidfVectorizer
 from gensim.models import TfidfModel
@@ -31,6 +32,8 @@ class TfIdf(BasicProcessor):
 	title = "Tf-idf"  # title displayed in UI
 	description = "Get the tf-idf values of tokenised text. Works better with more documents (e.g. time-separated)."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a ranking table (date/item/value), so ranking visualisations can run on it
+	output = Table(columns={"date", "item", "value"})
 
 	# Allow processor on token sets
 	compatibility = Compatibility(

--- a/processors/text-analysis/tokenise.py
+++ b/processors/text-analysis/tokenise.py
@@ -18,6 +18,7 @@ from razdel.substring import Substring
 from common.lib.helpers import UserInput, get_interval_descriptor
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Archive
 
 __author__ = ["Stijn Peeters", "Sal Hagen"]
 __credits__ = ["Stijn Peeters", "Sal Hagen"]
@@ -36,6 +37,9 @@ class Tokenise(BasicProcessor):
                   "The output is a list of lists, each list representing all item tokens or " \
                   "tokens per sentence."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
+
+    # a zip archive of data files
+    output = Archive()
 
     compatibility = Compatibility(extensions={"csv", "ndjson"}, preferred_followups=["collocations", "vectorise-tokens", "generate-embeddings", "tfidf", "topic-modeller", ])
 

--- a/processors/text-analysis/top_vectors.py
+++ b/processors/text-analysis/top_vectors.py
@@ -8,6 +8,7 @@ import json
 from common.lib.helpers import UserInput, convert_to_int
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -24,6 +25,8 @@ class VectorRanker(BasicProcessor):
 	description = "Ranks most used tokens per token set (overall or per timeframe). " \
 				  "Limited to 100 most-used tokens."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+	# a ranking table (date/item/value), so ranking visualisations can run on it
+	output = Table(columns={"date", "item", "value"})
 
 	# Allow processor on token vectors
 	compatibility = Compatibility(types={"vectorise-tokens"}, preferred_followups=["wordcloud"])

--- a/processors/text-analysis/topic_modeling.py
+++ b/processors/text-analysis/topic_modeling.py
@@ -5,6 +5,7 @@ Create topic clusters based on datasets
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Archive
 from common.lib.exceptions import ProcessorInterruptedException
 
 import json
@@ -31,6 +32,9 @@ class TopicModeler(BasicProcessor):
                   "For a given number of topics, tokens are assigned a relevance weight per topic, " \
                   "which can be used to find clusters of related words."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
+
+    # a zip archive of data files
+    output = Archive()
 
     # Allow processor on token sets
     compatibility = Compatibility(types={"tokenise-posts"}, preferred_followups=["document_count", "document_topic_matrix", "topic-model-words"])

--- a/processors/text-analysis/topic_words.py
+++ b/processors/text-analysis/topic_words.py
@@ -5,6 +5,7 @@ Extracts topics per model and top associated words
 from common.lib.helpers import UserInput
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 
 import pickle
@@ -24,6 +25,8 @@ class TopicModelWordExtractor(BasicProcessor):
     title = "Top words per topic"  # title displayed in UI
     description = "Creates a CSV file with the top tokens (words) per topic in the generated topic model, and their associated weights."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on topic models
     compatibility = Compatibility(types={"topic-modeller"}, preferred_followups=["wordcloud"])

--- a/processors/text-analysis/vectorise.py
+++ b/processors/text-analysis/vectorise.py
@@ -7,6 +7,7 @@ import itertools
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Archive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -22,6 +23,8 @@ class Vectorise(BasicProcessor):
 	title = "Count words"  # title displayed in UI
 	description = "Counts how often a token appears in the dataset. This creates a bag of words."  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
+	# a zip archive of data files
+	output = Archive()
 
 	# Allow processor on token sets
 	compatibility = Compatibility(types={"tokenise-posts"}, preferred_followups=["vector-ranker"])

--- a/processors/text-analysis/vectorise_by_cat.py
+++ b/processors/text-analysis/vectorise_by_cat.py
@@ -7,6 +7,7 @@ import pickle
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.helpers import UserInput
 
 __author__ = "Dale Wahl"
@@ -23,6 +24,9 @@ class VectoriseByCategory(BasicProcessor):
 	title = "Count words by category"  # title displayed in UI
 	description = "Counts all tokens per category."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+
+	# a ranking table (date/item/value), so ranking visualisations can run on it
+	output = Table(columns={"date", "item", "value"})
 
 	# Allow processor on token sets
 	compatibility = Compatibility(

--- a/processors/twitter/aggregate_stats.py
+++ b/processors/twitter/aggregate_stats.py
@@ -8,6 +8,7 @@ import statistics
 from common.lib.helpers import UserInput, pad_interval, get_interval_descriptor
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render, Table
 from common.lib.exceptions import ProcessorException
 
 __author__ = "Dale Wahl"
@@ -25,6 +26,8 @@ class TwitterAggregatedStats(BasicProcessor):
     title = "Aggregated statistics"  # title displayed in UI
     description = "Group tweets by category and count tweets per timeframe and then calculate aggregate group statistics (i.e. min, max, average, Q1, median, Q3, and trimmed mean): number of tweets, urls, hashtags, mentions, etc. \nUse for example to find the distribution of the number of tweets per author and compare across time."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})
@@ -257,6 +260,8 @@ class TwitterAggregatedStatsVis(TwitterAggregatedStats):
     title = "Aggregated Statistics Visualization"  # title displayed in UI
     description = "Gathers Aggregated Statistics data and creates Box Plots visualising the spread of intervals. A large number of intervals will not properly display. "  # description displayed in UI
     extension = "png"  # extension of result file, used internally and in UI
+    # a rendered image, no column table
+    output = Render("png")
 
     references = [
         "[matplotlib.pyplot.boxplot documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.boxplot.html)"

--- a/processors/twitter/custom_stats.py
+++ b/processors/twitter/custom_stats.py
@@ -5,6 +5,7 @@ from common.lib.exceptions import ProcessorException
 from common.lib.helpers import UserInput
 from processors.twitter.base_twitter_stats import TwitterStatsBase
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -21,6 +22,8 @@ class TwitterCustomStats(TwitterStatsBase):
     title = "Custom statistics"  # title displayed in UI
     description = "Group tweets by category and count tweets per timeframe to collect aggregate group statistics.\nFor retweets and quotes, hashtags, mentions, URLs, and images from the original tweet are included in the retweet/quote. Data on public metrics (e.g., number of retweets or likes of tweets) are as of the time the data was collected."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/twitter/hashtag_stats.py
+++ b/processors/twitter/hashtag_stats.py
@@ -4,6 +4,7 @@ Twitter APIv2 hashtag statistics
 from common.lib.helpers import UserInput
 from processors.twitter.base_twitter_stats import TwitterStatsBase
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -20,6 +21,8 @@ class TwitterHashtagStats(TwitterStatsBase):
     title = "Hashtag statistics"  # title displayed in UI
     description = "Lists by hashtag how many tweets contain hashtags, how many times those tweets have been retweeted/replied to/liked/quoted, and information about unique users and hashtags used alongside each hashtag.\nFor retweets and quotes, hashtags from the original tweet are included in the retweet/quote."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/twitter/identical_tweets.py
+++ b/processors/twitter/identical_tweets.py
@@ -4,6 +4,7 @@ Twitter APIv2 hashtag statistics
 from common.lib.helpers import UserInput
 from processors.twitter.base_twitter_stats import TwitterStatsBase
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -20,6 +21,9 @@ class TwitterIdenticalTweets(TwitterStatsBase):
     title = "Identical tweet frequency"  # title displayed in UI
     description = "Groups tweets by text and counts the number of times they have been (re)tweeted indentically."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/twitter/mention_export.py
+++ b/processors/twitter/mention_export.py
@@ -5,6 +5,7 @@ import csv
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorException, ProcessorInterruptedException
 
 __author__ = "Dale Wahl"
@@ -22,6 +23,8 @@ class TwitterMentionsExport(BasicProcessor):
     title = "Mentions export"  # title displayed in UI
     description = "Identifies mentions types and creates mentions table (tweet id, from author id, from username, to user id, to username, mention type)"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X (API v2) datasets
     compatibility = Compatibility(types={"twitterv2-search"})
@@ -143,6 +146,8 @@ class TCATMentionsExport(BasicProcessor):
     title = "Mentions Export"  # title displayed in UI
     description = "Identifies mentions types and creates mentions table (tweet id, from author id, from username, to username)"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on imported TCAT datasets
     compatibility = Compatibility(types={"dmi-tcat-search"})

--- a/processors/twitter/source_stats.py
+++ b/processors/twitter/source_stats.py
@@ -4,6 +4,7 @@ Twitter APIv2 hashtag statistics
 from common.lib.helpers import UserInput
 from processors.twitter.base_twitter_stats import TwitterStatsBase
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -20,6 +21,9 @@ class TwitterHashtagStats(TwitterStatsBase):
     title = "Source statistics"  # title displayed in UI
     description = "Lists by source of tweet how many tweets contain hashtags, how many times those tweets have been retweeted/replied to/liked/quoted, and information about unique users and hashtags used alongside each hashtag.\nFor retweets and quotes, hashtags from the original tweet are included in the retweet/quote."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/twitter/twitter_stats.py
+++ b/processors/twitter/twitter_stats.py
@@ -4,6 +4,7 @@ Twitter APIv2 general tweet statistics
 from common.lib.helpers import UserInput
 from processors.twitter.base_twitter_stats import TwitterStatsBase
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl"]
@@ -20,6 +21,8 @@ class TwitterStats(TwitterStatsBase):
     title = "Twitter statistics"  # title displayed in UI
     description = "Contains the number of tweets, number of tweets with links, number of tweets with hashtags, number of tweets with mentions, number of retweets, and number of replies"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/twitter/user_stats_individual.py
+++ b/processors/twitter/user_stats_individual.py
@@ -4,6 +4,7 @@ Twitter APIv2 individual user statistics
 from common.lib.helpers import UserInput
 from processors.twitter.base_twitter_stats import TwitterStatsBase
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorException
 
 __author__ = "Dale Wahl"
@@ -21,6 +22,8 @@ class TwitterStats(TwitterStatsBase):
     title = "Individual user statistics"  # title displayed in UI
     description = "Lists users and their number of tweets, number of followers, number of friends, how many times they are listed, their UTC time offset, whether the user has a verified account and how many times they appear in the data set."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/twitter/user_visibility.py
+++ b/processors/twitter/user_visibility.py
@@ -6,6 +6,7 @@ import datetime
 from common.lib.helpers import get_interval_descriptor
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 
@@ -24,6 +25,9 @@ class TwitterUserVisibility(BasicProcessor):
     title = "User visibility"  # title displayed in UI
     description = "Collects usernames and totals how many tweets are authored by the user and how many tweets mention the user"  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+
+    # a derived table
+    output = Table()
 
     # Allow processor on Twitter/X datasets (API v2 or imported TCAT)
     compatibility = Compatibility(types={"twitterv2-search", "dmi-tcat-search"})

--- a/processors/visualisation/download-telegram-images.py
+++ b/processors/visualisation/download-telegram-images.py
@@ -9,6 +9,7 @@ from common.lib.helpers import UserInput
 from processors.visualisation.download_images import ImageDownloader
 from processors.visualisation.download_telegram_videos import TelegramVideoDownloader
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -31,6 +32,8 @@ class TelegramImageDownloader(TelegramVideoDownloader):
                   "Note that not always all images can be retrieved. A JSON metadata file is included in the output " \
                   "archive."
     extension = "zip"
+    # a zip archive of media files
+    output = MediaArchive(media="image")
     media_type = "image"
 
     # coarse map spec; is_compatible_with (below) is the runtime truth (Telegram API creds)

--- a/processors/visualisation/download_images.py
+++ b/processors/visualisation/download_images.py
@@ -15,6 +15,7 @@ from backend.lib.processor import BasicProcessor
 from backend.lib.proxied_requests import FailedProxiedRequest
 from common.lib.exceptions import ProcessorInterruptedException, FourcatException
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -44,6 +45,9 @@ class ImageDownloader(BasicProcessor):
     )  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
     media_type = "image"  # media type of the dataset
+
+    # a zip archive of media files
+    output = MediaArchive(media="image")
 
     # Shared list -- other download_* processors reuse this as ImageDownloader.followups
     # (and preferred_followups below reuses it), so it stays a named attribute.

--- a/processors/visualisation/download_telegram_files.py
+++ b/processors/visualisation/download_telegram_files.py
@@ -15,6 +15,7 @@ from telethon import utils as telethon_utils
 from common.lib.helpers import UserInput
 from processors.visualisation.download_telegram_videos import TelegramVideoDownloader
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -41,6 +42,8 @@ class TelegramFileDownloader(TelegramVideoDownloader):
                    "owner has asked clients not to save its content and Telegram will refuse "
                    "the file fetch.")
     extension = "zip"
+    # a zip archive of media files
+    output = MediaArchive(media="file")
     media_type = "file"
 
     # coarse map spec; is_compatible_with (below) is the runtime truth (Telegram API creds).

--- a/processors/visualisation/download_telegram_videos.py
+++ b/processors/visualisation/download_telegram_videos.py
@@ -23,6 +23,7 @@ from processors.visualisation.download_videos import VideoDownloaderPlus
 from common.lib.helpers import UserInput, timify
 from common.lib.dataset import DataSet
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters", "Dale Wahl"]
@@ -45,6 +46,8 @@ class TelegramVideoDownloader(BasicProcessor):
                   "archive."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
     media_type = "video"  # media type of the result
+    # a zip archive of media files
+    output = MediaArchive(media="video")
     flawless = True
 
     # coarse map spec; is_compatible_with (below) is the runtime truth -- it also checks the

--- a/processors/visualisation/download_tiktok.py
+++ b/processors/visualisation/download_tiktok.py
@@ -17,6 +17,7 @@ from datasources.tiktok.search_tiktok import SearchTikTok as SearchTikTokByImpor
 from processors.visualisation.download_images import ImageDownloader
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 
 
 __author__ = "Dale Wahl"
@@ -30,6 +31,8 @@ class TikTokImageDownloader(BasicProcessor):
     title = "Download TikTok images"  # title displayed in UI
     description = "Downloads video/music thumbnails for TikTok; refreshes TikTok data if URLs have expired"
     extension = "zip"
+    # a zip archive of media files
+    output = MediaArchive(media="image")
     media_type = "image"
 
     # Allow processor on TikTok datasets

--- a/processors/visualisation/download_tiktok_video.py
+++ b/processors/visualisation/download_tiktok_video.py
@@ -13,6 +13,7 @@ from processors.visualisation.download_videos import VideoDownloaderPlus
 from backend.lib.processor import BasicProcessor
 from datasources.tiktok_urls.search_tiktok_urls import TikTokScraper
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive, Table
 
 class TikTokVideoDownloader(ProcessorPreset):
     """
@@ -26,6 +27,8 @@ class TikTokVideoDownloader(ProcessorPreset):
     description = "Downloads full videos for TikTok"
     extension = "zip"
     media_type = "video"
+    # its pipeline downloads the videos into a zip archive
+    output = MediaArchive(media="video")
 
     # coarse map spec; is_compatible_with (below) is the runtime truth -- it also accepts
     # tiktok uploads, which depends on the dataset label and can't be declared statically
@@ -125,6 +128,8 @@ class TikTokVideoMetadata(BasicProcessor):
     description = "Retrieves updated video URLs from TikTok"
     extension = "csv"
     media_type = "text"
+    # a derived table
+    output = Table()
 
     consecutive_failures = None
 

--- a/processors/visualisation/download_videos.py
+++ b/processors/visualisation/download_videos.py
@@ -21,6 +21,7 @@ from yt_dlp.utils import ExistingVideoReached
 from backend.lib.processor import BasicProcessor
 from backend.lib.proxied_requests import FailedProxiedRequest
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 from common.lib.dataset import DataSet
 from common.lib.exceptions import ProcessorInterruptedException, ProcessorException, DataSetException
 from common.lib.helpers import UserInput, sets_to_lists, url_to_filename
@@ -95,6 +96,9 @@ class VideoDownloaderPlus(BasicProcessor):
                   "retrieved externally."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
     media_type = "video"  # media type of the processor
+
+    # a zip archive of media files
+    output = MediaArchive(media="video")
 
     # Shared list -- other download_* processors reuse this as VideoDownloaderPlus.followups
     # (and preferred_followups below reuses it), so it stays a named attribute.

--- a/processors/visualisation/histwords.py
+++ b/processors/visualisation/histwords.py
@@ -13,6 +13,7 @@ from gensim.models import KeyedVectors
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 from common.lib.helpers import UserInput, convert_to_int, get_4cat_canvas, convert_to_float
 from common.lib.exceptions import ProcessorInterruptedException
 
@@ -41,6 +42,9 @@ class HistWordsVectorSpaceVisualiser(BasicProcessor):
     title = "Chart diachronic nearest neighbours"  # title displayed in UI
     description = "Visualise nearest neighbours of a given query across all models and show the closest neighbours per model in one combined graph. Based on the 'HistWords' algorithm by Hamilton et al."  # description displayed in UI
     extension = "svg"  # extension of result file, used internally and in UI
+
+    # a rendered image, no column table
+    output = Render()
 
     # Allow processor on word embedding models
     compatibility = Compatibility(types={"generate-embeddings"})

--- a/processors/visualisation/image_category_wall.py
+++ b/processors/visualisation/image_category_wall.py
@@ -18,6 +18,7 @@ from common.lib.helpers import UserInput, convert_to_int, get_4cat_canvas
 from backend.lib.processor import BasicProcessor
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl", "Stijn Peeters"]
@@ -36,6 +37,9 @@ class ImageCategoryWallGenerator(BasicProcessor):
     title = "Visualise images by category"  # title displayed in UI
     description = "Combine images into a single image arranged by category"  # description displayed in UI
     extension = "svg"  # extension of result file, used internally and in UI
+
+    # a rendered image, no column table
+    output = Render()
 
     # image-category, image-downloader, or video-hash datasets (except screenshot downloads)
     compatibility = Compatibility(type_prefixes={"image-to-categories", "image-downloader", "video-hasher-1", "video-hash-similarity-matrix"}, excluded_types={"image-downloader-screenshots-search"})

--- a/processors/visualisation/image_wall.py
+++ b/processors/visualisation/image_wall.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageOps, UnidentifiedImageError
 from sklearn.cluster import KMeans
 from common.lib.helpers import UserInput
 from common.lib.compatibility import Compatibility, ExecutableSibling
+from common.lib.outputs import Render
 import colorsys
 import copy
 
@@ -29,6 +30,8 @@ class ImageWallGenerator(VideoWallGenerator):
     title = "Image wall"
     description = "Put all images in a single combined image, side by side. Images can be sorted and resized."
     extension = "png"
+    # a rendered image, no column table
+    output = Render("png")
 
     # Allow on image/video datasets when ffmpeg and ffprobe are available
     compatibility = Compatibility(media_types={"video", "image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})

--- a/processors/visualisation/image_wall.py
+++ b/processors/visualisation/image_wall.py
@@ -34,7 +34,7 @@ class ImageWallGenerator(VideoWallGenerator):
     output = Render("png")
 
     # Allow on image/video datasets when ffmpeg and ffprobe are available
-    compatibility = Compatibility(media_types={"video", "image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video", "image"}, type_prefixes={"image-downloader"}, types={"video-frames"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})
 
     @classmethod
     def get_options(cls, parent_dataset=None, config=None):

--- a/processors/visualisation/image_wall_w_text.py
+++ b/processors/visualisation/image_wall_w_text.py
@@ -19,6 +19,7 @@ from common.lib.helpers import UserInput, convert_to_int, get_4cat_canvas
 from backend.lib.processor import BasicProcessor
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 __author__ = "Dale Wahl"
 __credits__ = ["Dale Wahl", "Stijn Peeters"]
@@ -35,6 +36,9 @@ class ImageTextWallGenerator(BasicProcessor):
     title = "Image wall with captions"  # title displayed in UI
     description = "Combine images into a single image including text"  # description displayed in UI
     extension = "svg"  # extension of result file, used internally and in UI
+
+    # a rendered image, no column table
+    output = Render()
 
     image_datasets = ["image-downloader", "video-hasher-1"]
     caption_datasets = ["image-captions", "text-from-images"]

--- a/processors/visualisation/isoviz.py
+++ b/processors/visualisation/isoviz.py
@@ -7,6 +7,7 @@ import re
 from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput, convert_to_int, pad_interval, get_4cat_canvas
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 from calendar import month_abbr
 from math import sin, cos, tan, degrees, radians, copysign
@@ -35,6 +36,8 @@ class IsometricMultigraphRenderer(BasicProcessor):
 	title = "Side-by-side area graphs"  # title displayed in UI
 	description = "Generate area graphs showing prevalence per item over time. These are visualised side-by-side on an isometric plane for easy comparison."  # description displayed in UI
 	extension = "svg"  # extension of result file, used internally and in UI
+	# a rendered image, no column table
+	output = Render()
 	icon = "chart-area"
 
 	# rankable datasets with a single value per item (multiple_items=False)

--- a/processors/visualisation/rankflow.py
+++ b/processors/visualisation/rankflow.py
@@ -8,6 +8,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput, get_4cat_canvas
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 from svgwrite.shapes import Rect
 from svgwrite.path import Path
@@ -41,6 +42,8 @@ class RankFlowRenderer(BasicProcessor):
         "Bernhard Rieder's RankFlow."
     )  # description displayed in UI
     extension = "svg"  # extension of result file, used internally and in UI
+    # a rendered image, no column table
+    output = Render()
 
     # rankable datasets, including multi-column rankings (e.g. top vectors per interval)
     compatibility = Compatibility(rankable=True)

--- a/processors/visualisation/vector_histogram.py
+++ b/processors/visualisation/vector_histogram.py
@@ -13,6 +13,7 @@ from svgwrite.text import Text
 from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput, pad_interval, get_4cat_canvas
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 __author__ = "Stijn Peeters"
 __credits__ = ["Stijn Peeters"]
@@ -29,6 +30,9 @@ class SVGHistogramRenderer(BasicProcessor):
 	description = "Generates a histogram from time frequencies."  # description displayed in UI
 	extension = "svg"
 	icon = "square-poll-vertical"
+
+	# a rendered image, no column table
+	output = Render()
 
 	# rankable datasets with a single value per item (multiple_items=False)
 	compatibility = Compatibility(rankable=True, rankable_multiple_items=False)

--- a/processors/visualisation/video_frames.py
+++ b/processors/visualisation/video_frames.py
@@ -36,7 +36,7 @@ class VideoFrames(BasicProcessor):
 	output = MediaArchive(media="image")
 
 	# Allow on video datasets when ffmpeg is available
-	compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)}, preferred_followups=["video-timelines"] + VideoDownloaderPlus.followups)
+	compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)}, preferred_followups=["video-timelines"] + VideoDownloaderPlus.followups)
 
 	@classmethod
 	def get_options(cls, parent_dataset=None, config=None) -> dict:

--- a/processors/visualisation/video_frames.py
+++ b/processors/visualisation/video_frames.py
@@ -9,6 +9,7 @@ import oslex
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility, is_executable
+from common.lib.outputs import MediaArchive
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 from processors.visualisation.download_videos import VideoDownloaderPlus
@@ -30,6 +31,9 @@ class VideoFrames(BasicProcessor):
 	title = "Extract frames from videos"  # title displayed in UI
 	description = "Extract frames from videos"  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
+	media_type = "image"  # the extracted frames are images; set so the map and runtime agree
+	# a zip archive of image files
+	output = MediaArchive(media="image")
 
 	# Allow on video datasets when ffmpeg is available
 	compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)}, preferred_followups=["video-timelines"] + VideoDownloaderPlus.followups)

--- a/processors/visualisation/video_hasher.py
+++ b/processors/visualisation/video_hasher.py
@@ -40,7 +40,7 @@ class VideoHasherPreset(ProcessorAdvancedPreset):
     output = Delegated()
 
     # video datasets, when ffmpeg is available
-    compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
 
     @classmethod
     def get_options(cls, parent_dataset=None, config=None):
@@ -140,7 +140,7 @@ class VideoHasher(BasicProcessor):
     output = MediaArchive(media="image")
 
     # video datasets (collages are made from video frames)
-    compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, preferred_followups=["video-hash-network", "video-hash-similarity-matrix"])
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, preferred_followups=["video-hash-network", "video-hash-similarity-matrix"])
 
     @classmethod
     def get_options(cls, parent_dataset=None, config=None):

--- a/processors/visualisation/video_hasher.py
+++ b/processors/visualisation/video_hasher.py
@@ -17,6 +17,7 @@ from videohash.exceptions import FFmpegNotFound, FFmpegFailedToExtractFrames
 from backend.lib.processor import BasicProcessor
 from backend.lib.preset import ProcessorAdvancedPreset
 from common.lib.compatibility import Compatibility, is_executable
+from common.lib.outputs import Network, MediaArchive, Table, Delegated
 from common.lib.exceptions import ProcessorInterruptedException, ProcessorException
 from common.lib.user_input import UserInput
 
@@ -35,6 +36,8 @@ class VideoHasherPreset(ProcessorAdvancedPreset):
     title = "Create video hashes to identify near duplicate videos"  # title displayed in UI
     description = "Creates video hashes (64 bits/identifiers) to identify near duplicate videos in a dataset based on hash similarity. Uses video only. This process can take a long time depending on video length, amount, and frames per second."
     extension = "gexf"
+    # a preset; its output is its last step's
+    output = Delegated()
 
     # video datasets, when ffmpeg is available
     compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", is_executable)})
@@ -133,6 +136,8 @@ class VideoHasher(BasicProcessor):
     description = "Creates collages from video frames. Can be used to create video hashes to detect similar videos."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
     media_type = "image" # media type of the result
+    # a zip archive of image files (video-frame collages)
+    output = MediaArchive(media="image")
 
     # video datasets (collages are made from video frames)
     compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, preferred_followups=["video-hash-network", "video-hash-similarity-matrix"])
@@ -338,6 +343,8 @@ class VideoHashNetwork(BasicProcessor):
     title = "Create Video hashes network"  # title displayed in UI
     description = "Creates hashes network to identify duplicate or similar videos."  # description displayed in UI
     extension = "gexf"  # extension of result file, used internally and in UI
+    # a graph file, no column table
+    output = Network()
 
     # Allow on video hasher
     compatibility = Compatibility(types={"video-hasher-1"})
@@ -452,6 +459,8 @@ class VideoHashSimilarities(BasicProcessor):
     title = "Calculates hashes and similarity groups"  # title displayed in UI
     description = "Creates CSV with hashes and groups videos above similarity value."  # description displayed in UI
     extension = "csv"  # extension of result file, used internally and in UI
+    # a derived table
+    output = Table()
 
     # Allow on video hasher
     compatibility = Compatibility(types={"video-hasher-1"})

--- a/processors/visualisation/video_scene_frames.py
+++ b/processors/visualisation/video_scene_frames.py
@@ -13,6 +13,7 @@ from packaging import version
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility, is_executable
+from common.lib.outputs import MediaArchive
 from common.lib.user_input import UserInput
 from common.lib.helpers import get_ffmpeg_version
 
@@ -33,6 +34,9 @@ class VideoSceneFrames(BasicProcessor):
     title = "Extract key frames from each scene"  # title displayed in UI
     description = "For each scene identified, extracts a key frame (e.g. the first frame)."  # description displayed in UI
     extension = "zip"  # extension of result file, used internally and in UI
+    media_type = "image"  # the extracted frames are images; set so the map and runtime agree
+    # a zip archive of image files
+    output = MediaArchive(media="image")
 
     # Allow on detected video scenes when ffmpeg is available
     compatibility = Compatibility(types={"video-scene-detector"}, required_settings={("video-downloader.ffmpeg_path", is_executable)}, preferred_followups=["video-timelines"])

--- a/processors/visualisation/video_scene_identifier.py
+++ b/processors/visualisation/video_scene_identifier.py
@@ -11,6 +11,7 @@ from scenedetect import open_video, SceneManager, VideoOpenFailure, FrameTimecod
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Table
 from common.lib.exceptions import ProcessorInterruptedException, ProcessorException
 from common.lib.user_input import UserInput
 
@@ -39,6 +40,9 @@ class VideoSceneDetector(BasicProcessor):
 	description = "Detect distinct 'scenes' in videos based on various parameters (e.g. change in color and " \
 				  "intensity or cuts and fades to black) and extract the scene metadata."  # description displayed in UI
 	extension = "csv"  # extension of result file, used internally and in UI
+
+	# a derived table
+	output = Table()
 
 	# Allow on video datasets
 	compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, preferred_followups=["video-scene-frames", "video-timelines"])

--- a/processors/visualisation/video_scene_identifier.py
+++ b/processors/visualisation/video_scene_identifier.py
@@ -45,7 +45,7 @@ class VideoSceneDetector(BasicProcessor):
 	output = Table()
 
 	# Allow on video datasets
-	compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, preferred_followups=["video-scene-frames", "video-timelines"])
+	compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, preferred_followups=["video-scene-frames", "video-timelines"])
 
 	references = [
 		"[PySceneDetect](https://github.com/Breakthrough/PySceneDetect)",

--- a/processors/visualisation/video_stack.py
+++ b/processors/visualisation/video_stack.py
@@ -41,7 +41,7 @@ class VideoStack(BasicProcessor):
     output = Render("mp4", media="video")
 
     # Allow on video datasets when ffmpeg and ffprobe are available
-    compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})
 
     @classmethod
     def get_options(cls, parent_dataset=None, config=None) -> dict:

--- a/processors/visualisation/video_stack.py
+++ b/processors/visualisation/video_stack.py
@@ -13,6 +13,7 @@ from packaging import version
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility, ExecutableSibling
+from common.lib.outputs import Render
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 from common.lib.helpers import get_ffmpeg_version
@@ -36,6 +37,8 @@ class VideoStack(BasicProcessor):
                   "transparently to help visualise similarities. Does not work well with more than a dozen or so " \
                   "videos. Videos are stacked by length, i.e. the longest video is at the 'bottom' of the stack."  # description displayed in UI
     extension = "mp4"  # extension of result file, used internally and in UI
+    # a rendered video, no column table
+    output = Render("mp4", media="video")
 
     # Allow on video datasets when ffmpeg and ffprobe are available
     compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})

--- a/processors/visualisation/video_timelines.py
+++ b/processors/visualisation/video_timelines.py
@@ -15,6 +15,7 @@ from ural import is_url
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.user_input import UserInput
 from common.lib.helpers import get_4cat_canvas
@@ -38,6 +39,8 @@ class VideoTimelines(BasicProcessor):
     description = "For each video for which frames were extracted, create a video timeline (i.e. a horizontal " \
                   "collage of sequential frames). Timelines are then vertically stacked."  # description displayed in UI
     extension = "svg"  # extension of result file, used internally and in UI
+    # a rendered image, no column table
+    output = Render()
 
     # Compatible with extracted video frames (or anything that stores related
     # images in separate folders within a zip archive).

--- a/processors/visualisation/video_wall.py
+++ b/processors/visualisation/video_wall.py
@@ -13,6 +13,7 @@ from packaging import version
 from common.lib.helpers import UserInput, get_ffmpeg_version, convert_to_int
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility, ExecutableSibling
+from common.lib.outputs import Render
 from common.lib.exceptions import ProcessorInterruptedException, MediaSignatureException
 
 __author__ = "Stijn Peeters"
@@ -34,6 +35,9 @@ class VideoWallGenerator(BasicProcessor):
     title = "Video wall"  # title displayed in UI
     description = "Put all videos in a single combined video, side by side. Videos can be sorted and resized."
     extension = "mp4"  # extension of result file, used internally and in UI
+
+    # a rendered video, no column table
+    output = Render("mp4", media="video")
 
     # Allow on video datasets when ffmpeg and ffprobe are available
     compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})

--- a/processors/visualisation/video_wall.py
+++ b/processors/visualisation/video_wall.py
@@ -40,7 +40,7 @@ class VideoWallGenerator(BasicProcessor):
     output = Render("mp4", media="video")
 
     # Allow on video datasets when ffmpeg and ffprobe are available
-    compatibility = Compatibility(media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})
+    compatibility = Compatibility(extensions={"zip"}, media_types={"video"}, type_prefixes={"video-downloader"}, required_settings={("video-downloader.ffmpeg_path", ExecutableSibling("ffmpeg", "ffprobe"))})
 
     # videos will be arranged and resized to fit these image wall dimensions
     # note that video aspect ratio may not allow for a precise fit

--- a/processors/visualisation/word-cloud.py
+++ b/processors/visualisation/word-cloud.py
@@ -7,6 +7,7 @@ from wordcloud import WordCloud
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 from common.lib.helpers import UserInput
 
 __author__ = "Sal Hagen"
@@ -24,6 +25,8 @@ class MakeWordCloud(BasicProcessor):
 	title = "Word cloud"  # title displayed in UI
 	description = "Generates a word cloud with words sized on occurrence."  # description displayed in UI
 	extension = "svg"
+	# a rendered image, no column table
+	output = Render()
 
 	# Allow processor on rankable items
 	compatibility = Compatibility(types={

--- a/processors/visualisation/word-trees.py
+++ b/processors/visualisation/word-trees.py
@@ -10,6 +10,7 @@ from backend.lib.processor import BasicProcessor
 from common.lib.helpers import UserInput, convert_to_int, get_4cat_canvas
 from common.lib.exceptions import QueryParametersException
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 
 from nltk.tokenize import word_tokenize, TweetTokenizer
 
@@ -198,6 +199,8 @@ class MakeWordtree(BasicProcessor):
     title = "Word tree"  # title displayed in UI
     description = "Generates a word tree for a given query, a \"graphical version of the traditional 'keyword-in-context' method\" (Wattenberg & Viégas, 2008)."  # description displayed in UI
     extension = "svg"  # extension of result file, used internally and in UI
+    # a rendered image, no column table
+    output = Render()
 
     # any csv or ndjson dataset
     compatibility = Compatibility(extensions={"csv", "ndjson"})

--- a/processors/visualisation/youtube_imagewall.py
+++ b/processors/visualisation/youtube_imagewall.py
@@ -11,6 +11,7 @@ from PIL import Image, ImageOps, ImageDraw, ImageFont
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import Render
 from common.lib.helpers import UserInput, convert_to_int
 
 __author__ = "Sal Hagen"
@@ -32,6 +33,8 @@ class YouTubeImageWall(BasicProcessor):
     title = "YouTube thumbnails image wall"  # title displayed in UI
     description = "Make an image wall from YouTube video thumbnails."  # description displayed in UI
     extension = "png"  # extension of result file, used internally and in UI
+    # a rendered image, no column table
+    output = Render("png")
 
     # Allow processor on YouTube thumbnail sets
     compatibility = Compatibility(types={"youtube-thumbnails"})

--- a/processors/visualisation/youtube_thumbnails.py
+++ b/processors/visualisation/youtube_thumbnails.py
@@ -8,6 +8,7 @@ from apiclient.discovery import build
 
 from backend.lib.processor import BasicProcessor
 from common.lib.compatibility import Compatibility
+from common.lib.outputs import MediaArchive
 from common.lib.exceptions import ProcessorInterruptedException
 from common.lib.helpers import get_yt_compatible_ids, UserInput
 
@@ -29,6 +30,8 @@ class YouTubeThumbnails(BasicProcessor):
 	title = "Download YouTube thumbnails"  # title displayed in UI
 	description = "Downloads the thumbnails of YouTube videos and stores it in a zip archive."  # description displayed in UI
 	extension = "zip"  # extension of result file, used internally and in UI
+	# a zip archive of media files
+	output = MediaArchive(media="image")
 	media_type = "image"  # media type of the result
 
 	# Allow processor on YouTube metadata sets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""
+Shared pytest fixtures.
+
+These mirror the fixtures in test_modules.py so that other test modules (e.g.
+test_processor_map.py) can build the real module set without a database. Defining
+them here makes them available session-wide; test_modules.py keeps its own local
+copies, which simply override these for its own tests (standard pytest behaviour),
+so nothing about that file changes.
+"""
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+PATH_ROOT = Path(os.path.abspath(os.path.dirname(__file__))).joinpath("..").resolve()
+
+
+@pytest.fixture
+def mock_database():
+    """Mock the database connection."""
+    with patch("common.config_manager.Database") as mock_cfg_db, \
+         patch("backend.lib.worker.Database") as mock_worker_db:
+        mock_database_instance = MagicMock()
+        mock_cfg_db.return_value = mock_database_instance
+        mock_worker_db.return_value = mock_database_instance
+        yield mock_database_instance
+
+
+@pytest.fixture
+def mock_basic_config(tmp_path, mock_database):
+    """Set up a config reader without connecting it to the database."""
+    class mocked_config:
+        pass
+
+    mocked_basic_config = mocked_config()
+    mocked_basic_config.get = MagicMock(side_effect=lambda key, default=None, is_json=False, user=None, tags=None: {
+            "PATH_ROOT": PATH_ROOT,
+            "PATH_DATA": PATH_ROOT,
+            "PATH_LOGS": PATH_ROOT / "logs",
+            "PATH_EXTENSIONS": PATH_ROOT / "config/extensions",
+            "extensions.enabled": {},
+        }.get(key, default))
+    mocked_basic_config.load_user_settings = MagicMock()
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    yield mocked_basic_config
+
+
+@pytest.fixture
+def logger(mock_basic_config):
+    """Initialize the Logger and return it."""
+    from common.lib.logger import Logger
+    return Logger(logger_name="pytest", output=True,
+                  log_path=mock_basic_config.get("PATH_LOGS").joinpath("test.log"), log_level='DEBUG')
+
+
+@pytest.fixture
+def fourcat_modules(mock_basic_config):
+    """The real loaded module set, built with a mocked config (no database)."""
+    from common.lib.module_loader import ModuleCollector
+    return ModuleCollector(config=mock_basic_config)

--- a/tests/test_processor_map.py
+++ b/tests/test_processor_map.py
@@ -296,7 +296,7 @@ def test_processor_map_builds_and_answers(logger, fourcat_modules):
     how_to_run = info["how_to_run"]
     assert "notes" in how_to_run
     if not how_to_run.get("is_filter"):
-        assert "accepts" in how_to_run and "starting_points" in how_to_run
+        assert "accepts" in how_to_run and "examples" in how_to_run
     assert {"preferred", "filters", "others_by_category"} <= set(info["followups"])
 
     assert isinstance(pmap.search("data"), list)

--- a/tests/test_processor_map.py
+++ b/tests/test_processor_map.py
@@ -1,0 +1,387 @@
+"""
+Tests for the compatibility check, the output-description helper, and the processor-map
+query layer.
+
+Two halves:
+
+* plain unit tests on `Compatibility.check` -- comparing a spec against a subject
+  (a live dataset or a declared output), and the rule that an output leaving a value
+  UNKNOWN can only soften an answer to "maybe", never produce a false "no". No app
+  context needed.
+* tests against the real loaded modules (the `fourcat_modules` fixture from
+  test_modules.py): every processor declares an output, declarations agree with the
+  class attributes, and the map builds and answers questions.
+"""
+import pytest
+
+from common.lib.compatibility import Compatibility, UNKNOWN, Shape, DatasetShape
+
+
+# --- helpers ---------------------------------------------------------------
+
+def shape(type=None, extension=UNKNOWN, media=UNKNOWN, datasource=UNKNOWN,
+          top_level=False, from_collector=False, columns=UNKNOWN, columns_are_all=False):
+    """A declared output; anything left as UNKNOWN reads as 'the output didn't say'."""
+    return Shape(type=type, extension=extension, media=media, datasource=datasource,
+                 top_level=top_level, from_collector=from_collector,
+                 columns=columns, columns_are_all=columns_are_all)
+
+
+class FakeModule:
+    """A minimal live dataset exposing what DatasetShape reads."""
+
+    def __init__(self, type=None, extension=None, media_type=None, datasource=None,
+                 top=True, from_collector=False):
+        self.type = type
+        self._extension = extension
+        self._media_type = media_type
+        self.parameters = {"datasource": datasource} if datasource else {}
+        self._top = top
+        self._from_collector = from_collector
+
+    def get_extension(self):
+        return self._extension
+
+    def get_media_type(self):
+        return self._media_type
+
+    def is_top_dataset(self):
+        return self._top
+
+    def is_from_collector(self):
+        return self._from_collector
+
+
+# --- check() against a declared output -------------------------------------
+
+def test_check_definite_yes_and_no_on_known_media():
+    assert Compatibility(media_types={"audio"}).check(shape(media="audio")) == "yes"
+    assert Compatibility(media_types={"image"}).check(shape(media="audio")) == "no"
+
+
+def test_unknown_value_is_maybe_never_false_no():
+    # import_media sets its media only when it runs, so its output leaves media UNKNOWN;
+    # a processor wanting images then gets "maybe", never a false "no"
+    spec = Compatibility(media_types={"image"})
+    assert spec.check(shape(media=UNKNOWN, from_collector=True, top_level=True)) == "maybe"
+
+
+def test_unknown_extension_is_maybe_but_wrong_extension_is_no():
+    spec = Compatibility(extensions={"ndjson"})
+    assert spec.check(shape(extension=UNKNOWN)) == "maybe"   # the output didn't say
+    assert spec.check(shape(extension="csv")) == "no"        # definitely the wrong one
+    assert spec.check(shape(extension="ndjson")) == "yes"
+
+
+def test_column_requirement_softens_to_maybe():
+    spec = Compatibility(media_types={"audio"}, requires_all_columns={"author"})
+    # media matches, but the output hasn't declared its columns -> maybe
+    assert spec.check(shape(media="audio")) == "maybe"
+
+
+def test_filter_position_is_maybe():
+    # a filter's result may or may not be top-level -> top_level UNKNOWN -> maybe
+    assert Compatibility(top_dataset_only=True).check(shape(top_level=UNKNOWN)) == "maybe"
+
+
+def test_columns_requirement_resolved_against_declared_columns():
+    spec = Compatibility(requires_all_columns={"author", "body"})
+    # the output guarantees both -> yes
+    assert spec.check(shape(columns=frozenset({"author", "body", "id"}))) == "yes"
+    # a column not in the floor might still appear at run time -> maybe, never a false no
+    assert spec.check(shape(columns=frozenset({"author"}))) == "maybe"
+    # an output with no columns at all (columns_are_all) can never satisfy it -> no
+    assert spec.check(shape(columns=frozenset(), columns_are_all=True)) == "no"
+    # nothing declared -> maybe
+    assert spec.check(shape(columns=UNKNOWN)) == "maybe"
+
+
+def test_columns_any_requirement():
+    spec = Compatibility(requires_any_columns={"image", "video"})
+    assert spec.check(shape(columns=frozenset({"video"}))) == "yes"
+    assert spec.check(shape(columns=frozenset(), columns_are_all=True)) == "no"
+
+
+def test_rankable_derived_from_columns_and_extension():
+    spec = Compatibility(rankable=True)
+    # a csv guaranteeing the ranking columns is rankable
+    assert spec.check(shape(extension="csv", columns=frozenset({"date", "value", "item"}))) == "yes"
+    # a non-csv (a network) is definitely not rankable
+    assert spec.check(shape(extension="gexf", columns=frozenset(), columns_are_all=True)) == "no"
+    # columns unknown -> rankability unknown -> maybe
+    assert spec.check(shape(extension="csv")) == "maybe"
+
+
+# --- check() against a real dataset is only ever yes/no --------------------
+
+@pytest.mark.parametrize("spec, module, compatible", [
+    (Compatibility(types={"a"}), FakeModule(type="a"), True),
+    (Compatibility(types={"a"}), FakeModule(type="b"), False),
+    (Compatibility(media_types={"image"}), FakeModule(type="x", media_type="image"), True),
+    (Compatibility(media_types={"image"}), FakeModule(type="x", media_type="text"), False),
+    (Compatibility(extensions={"csv"}), FakeModule(type="x", extension="csv"), True),
+    (Compatibility(extensions={"csv"}), FakeModule(type="x", extension="ndjson"), False),
+    (Compatibility(top_dataset_only=True), FakeModule(type="x", top=True), True),
+    (Compatibility(top_dataset_only=True), FakeModule(type="x", top=False), False),
+    (Compatibility(child_only=True), FakeModule(type="x", top=False), True),
+    (Compatibility(child_only=True), FakeModule(type="x", top=True), False),
+    (Compatibility(excluded_types={"x"}), FakeModule(type="x"), False),
+    (Compatibility(datasources={"4chan"}), FakeModule(type="x", datasource="4chan"), True),
+    (Compatibility(datasources={"4chan"}), FakeModule(type="x", datasource="reddit"), False),
+    (Compatibility(is_collector=True), FakeModule(type="x", from_collector=True), True),
+    (Compatibility(is_collector=True), FakeModule(type="x", from_collector=False), False),
+])
+def test_live_path_behaviour_preserved(spec, module, compatible):
+    assert spec.is_compatible_with(module) is compatible
+
+
+def test_live_check_is_never_maybe():
+    # a real dataset knows all its values, so check() is only ever yes/no for a dataset
+    spec = Compatibility(media_types={"image"}, extensions={"csv"}, top_dataset_only=True)
+    for module in (FakeModule(type="x", media_type="image", extension="csv", top=True),
+                   FakeModule(type="x", media_type="text", extension="ndjson", top=False)):
+        assert spec.check(DatasetShape(module)) in ("yes", "no")
+
+
+# --- the output description is honest about what it cannot know ------------
+
+def test_infer_output_honour_traps(logger, fourcat_modules):
+    """
+    The fallback inference must stay honest on every real processor class: a value not
+    set on the class comes out UNKNOWN (never guessed). Tested against _infer_output
+    directly, so a processor that declares its own output does not hide a dishonest
+    inference.
+    """
+    from common.lib.outputs import _infer_output
+    from common.lib.compatibility import _declared_class_value, _maybe_call, is_collector as is_collector_fn
+
+    for ptype, processor in fourcat_modules.processors.items():
+        shape = _infer_output(processor)
+
+        # media: known iff declared on the class (below BasicProcessor), else UNKNOWN
+        declared_media = _declared_class_value(processor, "media_type")
+        if declared_media:
+            assert shape.media == declared_media, f"{ptype}: declared media lost"
+        else:
+            assert shape.media is UNKNOWN, f"{ptype}: undeclared media is not UNKNOWN"
+
+        # extension: a filter passes its parent's through (UNKNOWN); a value set on the
+        # class is trusted; an inherited default stays UNKNOWN, never a confident guess
+        is_filter = bool(_maybe_call(processor, "is_filter"))
+        declared_ext = _declared_class_value(processor, "extension")
+        if is_filter:
+            assert shape.extension is UNKNOWN, f"{ptype}: filter extension is not UNKNOWN"
+        elif declared_ext:
+            assert shape.extension == declared_ext, f"{ptype}: declared extension lost"
+        else:
+            assert shape.extension is UNKNOWN, f"{ptype}: inherited extension treated as fact"
+
+        # position/collector-ness: a collector is top-level; a filter's result can be made
+        # top-level and take on a -search type, so both are UNKNOWN; else a child
+        if is_collector_fn(processor):
+            assert shape.top_level is True and shape.from_collector is True, f"{ptype}: collector not top"
+        elif is_filter:
+            assert shape.top_level is UNKNOWN and shape.from_collector is UNKNOWN, f"{ptype}: filter not UNKNOWN"
+        else:
+            assert shape.top_level is False and shape.from_collector is False, f"{ptype}: not a child"
+
+
+def test_describe_output_reads_declared_media(logger, fourcat_modules):
+    """Cross-check: a media_type set directly on the class must show up as known."""
+    from common.lib.outputs import describe_output
+
+    checked = 0
+    for processor in fourcat_modules.processors.values():
+        own_media = vars(processor).get("media_type")
+        if own_media:
+            media = describe_output(processor).media
+            assert own_media == media or (isinstance(media, set) and own_media in media)
+            checked += 1
+    logger.info(f"verified {checked} processor(s) that declare media_type directly")
+
+
+# --- every processor declares its output, and the declaration is truthful ---
+
+def test_every_processor_declares_output(logger, fourcat_modules):
+    """The coverage gate: every processor should declare an `output` (an Output, usually
+    inherited from a base class). Lists any that still fall back to class inference."""
+    from common.lib.outputs import Output
+
+    missing = sorted(ptype for ptype, cls in fourcat_modules.processors.items()
+                     if not isinstance(getattr(cls, "output", None), Output))
+    logger.info(f"{len(fourcat_modules.processors) - len(missing)} of "
+                f"{len(fourcat_modules.processors)} processors declare an output")
+    if missing:
+        pytest.fail(f"{len(missing)} processor(s) declare no output:\n" + "\n".join(missing))
+
+
+def test_output_matches_class_attributes(logger, fourcat_modules):
+    """Where a processor declares both an `output` and the legacy class attributes, a
+    fixed output extension/media must equal the class one -- keeping the declaration
+    honest while the legacy attributes still exist (the eventual source to derive from)."""
+    from common.lib.outputs import Output
+    from common.lib.compatibility import _declared_class_value
+
+    mismatches = []
+    for ptype, cls in fourcat_modules.processors.items():
+        out = getattr(cls, "output", None)
+        if not isinstance(out, Output):
+            continue
+        shape = out.to_shape(cls)
+
+        declared_ext = _declared_class_value(cls, "extension")
+        if declared_ext and isinstance(shape.extension, str) and shape.extension != declared_ext:
+            mismatches.append(f"{ptype}: output extension {shape.extension!r} != class {declared_ext!r}")
+
+        declared_media = _declared_class_value(cls, "media_type")
+        if declared_media and isinstance(shape.media, str) and shape.media != declared_media:
+            mismatches.append(f"{ptype}: output media {shape.media!r} != class {declared_media!r}")
+
+    if mismatches:
+        pytest.fail("output does not match class attributes:\n" + "\n".join(sorted(mismatches)))
+
+
+def test_describe_spec_covers_every_compatibility_axis():
+    """
+    Every axis a Compatibility can declare must round-trip through describe_spec -- the
+    dict the catalogue displays and the map uses as the "requirement" label. Lockstep
+    insurance: add an axis without teaching describe_spec and this fails, rather than the
+    axis silently vanishing. A field is exempt only when it modifies another axis.
+    """
+    import dataclasses
+    from common.lib.compatibility import describe_spec
+
+    modifiers = {"rankable_multiple_items"}  # tunes `rankable`; not a standalone axis
+
+    def sample(name):
+        if name in ("rankable", "is_collector", "top_dataset_only", "child_only"):
+            return True
+        if name == "required_settings":
+            return ["some.setting"]
+        return {"x"}
+
+    missing = [field.name for field in dataclasses.fields(Compatibility)
+               if field.name not in modifiers
+               and field.name not in (describe_spec(Compatibility(**{field.name: sample(field.name)})) or {})]
+    assert not missing, ("describe_spec drops these Compatibility axes (add them to "
+                         "describe_spec, or to the modifiers exemption): %s" % missing)
+
+
+# --- the map builds and answers --------------------------------------------
+
+def test_processor_map_builds_and_answers(logger, fourcat_modules):
+    from common.lib.processor_map import ProcessorMap
+
+    pmap = ProcessorMap(fourcat_modules, config=None, logger=logger)
+
+    assert set(pmap.processors) == set(fourcat_modules.processors)  # nothing silently dropped
+
+    catalogue = pmap.catalogue()
+    assert len(catalogue) == len(fourcat_modules.processors)
+    for entry in catalogue:
+        assert {"type", "title", "is_datasource", "is_filter", "has_override"} <= set(entry)
+        assert "output_shape" not in entry  # browse rows stay light; shape is on the processor view
+
+    total_edges = sum(len(consumers) for consumers in pmap._succ.values())
+    assert total_edges > 0, "no edges -- the specs produced an empty map"
+
+    graph = pmap.graph()
+    assert graph["nodes"] and isinstance(graph["edges"], list)
+    for edge in graph["edges"]:
+        assert edge["certainty"] in ("definite", "maybe")
+
+    sample = next(iter(pmap.processors))
+    info = pmap.processor(sample)
+    assert {"how_to_run", "followups", "compatibility", "output_shape"} <= set(info)
+    how_to_run = info["how_to_run"]
+    assert "notes" in how_to_run
+    if not how_to_run.get("is_filter"):
+        assert "accepts" in how_to_run and "starting_points" in how_to_run
+    assert {"preferred", "filters", "others_by_category"} <= set(info["followups"])
+
+    assert isinstance(pmap.search("data"), list)
+
+
+def test_datasources_are_roots_not_consumers(logger, fourcat_modules):
+    """Collectors produce but never consume -- they have no incoming edges."""
+    from common.lib.processor_map import ProcessorMap
+
+    pmap = ProcessorMap(fourcat_modules, config=None, logger=logger)
+    for ptype, is_root in pmap._collector.items():
+        if is_root:
+            assert not pmap._pred.get(ptype), f"datasource {ptype} has incoming edges"
+
+
+# --- the author-facing archetypes ------------------------------------------
+
+class FakeProcessor:
+    """A stand-in processor class with just the attributes an Output reads."""
+
+    def __init__(self, type=None, extension="csv"):
+        self.type = type
+        self.extension = extension
+
+
+def test_datasource_archetype_uses_class_extension_and_text_media():
+    from common.lib.outputs import Datasource
+    shape = Datasource().to_shape(FakeProcessor(type="bsky-search", extension="ndjson"))
+    assert shape.extension == "ndjson"
+    assert shape.media == "text"
+    assert shape.top_level is True
+    assert shape.from_collector is True
+    assert shape.datasource == "bsky"  # a collector carries its datasource in its type
+    assert shape.produces_file
+
+
+def test_datasource_archetype_can_declare_columns():
+    from common.lib.outputs import Datasource
+    shape = Datasource(columns={"id", "body", "author"}).to_shape(FakeProcessor(type="x-search"))
+    assert shape.columns == frozenset({"id", "body", "author"})
+    assert Compatibility(requires_all_columns={"author"}).check(shape) == "yes"
+
+
+def test_filter_archetype_is_passthrough_everywhere():
+    from common.lib.outputs import Filter
+    shape = Filter().to_shape(FakeProcessor(type="x-filter"))
+    assert shape.extension is UNKNOWN
+    assert shape.media is UNKNOWN
+    assert shape.top_level is UNKNOWN
+    assert shape.from_collector is UNKNOWN
+    assert shape.columns is UNKNOWN
+
+
+def test_render_and_network_have_no_columns():
+    from common.lib.outputs import Render, Network
+    render = Render("svg").to_shape(FakeProcessor(type="x"))
+    assert render.extension == "svg"
+    assert render.media == "image"
+    assert render.columns == frozenset() and render.columns_are_all
+    network = Network().to_shape(FakeProcessor(type="x"))
+    assert network.extension == "gexf"
+    assert network.columns == frozenset() and network.columns_are_all
+
+
+def test_media_archive_bounded_media_set():
+    from common.lib.outputs import MediaArchive
+    shape = MediaArchive(media={"image", "video", "audio"}).to_shape(FakeProcessor(type="x"))
+    assert shape.extension == "zip"
+    assert shape.media == {"image", "video", "audio"}
+    # wanting image gets "maybe" (some, not all, of the set matches); wanting text is a no
+    assert Compatibility(media_types={"image"}).check(shape) == "maybe"
+    assert Compatibility(media_types={"text"}).check(shape) == "no"
+
+
+def test_no_output_produces_no_file():
+    from common.lib.outputs import NoOutput
+    assert NoOutput().to_shape(FakeProcessor(type="item-to-annotation")).produces_file is False
+
+
+def test_describe_output_prefers_declared_over_inference():
+    from common.lib.outputs import describe_output, Table
+
+    class Declared(FakeProcessor):
+        output = Table(columns={"date", "value", "item"})
+
+    shape = describe_output(Declared(type="x", extension="csv"))
+    assert shape.columns == frozenset({"date", "value", "item"})
+    assert Compatibility(rankable=True).check(shape) == "yes"  # rankability falls out of the columns

--- a/webtool/__init__.py
+++ b/webtool/__init__.py
@@ -179,6 +179,8 @@ with app.app_context():
     import webtool.views.views_explorer  # noqa: E402
     import webtool.views.api_standalone  # noqa: E402
     import webtool.views.api_tool  # noqa: E402
+    import webtool.views.api_processor_map  # noqa: E402
+    import webtool.views.views_processor_map  # noqa: E402
 
     app.register_blueprint(webtool.views.views_restart.component)
     app.register_blueprint(webtool.views.views_admin.component)
@@ -190,6 +192,8 @@ with app.app_context():
     app.register_blueprint(webtool.views.views_explorer.component)
     app.register_blueprint(webtool.views.api_standalone.component)
     app.register_blueprint(webtool.views.api_tool.component)
+    app.register_blueprint(webtool.views.api_processor_map.component)
+    app.register_blueprint(webtool.views.views_processor_map.component)
 
     @app.before_request
     def before_request():

--- a/webtool/static/css/processor-catalogue.css
+++ b/webtool/static/css/processor-catalogue.css
@@ -1,0 +1,84 @@
+/* Processor catalogue (prototype) -- a separate stylesheet so the shared 4CAT
+   styles stay untouched. Reuses 4CAT classes (view-controls, banner,
+   property-badge, metadata-wrapper) and adds only the catalogue-specific bits:
+   the detail panel, the search block, the prerequisite chain + groups. */
+
+/* detail panel, pinned above the search + catalogue */
+#pc-detail { border: 1px solid #ddd; border-radius: 8px; background: #fff; padding: 14px 18px; margin-bottom: 18px; }
+.pc-placeholder { color: #888; font-style: italic; margin: 0; }
+#pc-detail .metadata-wrapper { margin-bottom: 8px; }
+
+/* collapsible sections + prerequisite groups */
+.pc-section { border-top: 1px solid #eee; padding: 6px 0; }
+.pc-section > summary { cursor: pointer; font-weight: bold; font-size: 1.05em; padding: 4px 0; }
+.pc-section > summary:hover { color: #485ba6; }
+.pc-section-body { padding: 4px 0 8px; }
+.pc-grp { margin: 4px 0; padding-left: 6px; border-left: 2px solid #eee; }
+.pc-grp > summary { cursor: pointer; font-size: .92em; padding: 3px 0; }
+.pc-grp > summary:hover { color: #485ba6; }
+
+/* search / filter block -- prominent, below the detail */
+#pc-controls { background: #f6f7f9; border: 1px solid #e0e2e8; border-radius: 8px; padding: 12px 16px; margin-bottom: 18px; }
+.pc-browse-title { margin: 0 0 8px; }
+#pc-controls form { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
+#pc-controls form ul { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; margin: 0; padding: 0; list-style: none; }
+#pc-controls form li { margin: 0; }
+#pc-search { min-width: 280px; font-size: 1.05em; padding: 8px 12px; }
+#pc-category { min-width: 170px; padding: 7px 10px; }
+.pc-count { color: #666; font-size: .85em; }
+
+/* catalogue grid */
+.pc-cat { margin-bottom: 1.6em; }
+.pc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; }
+.pc-card { text-align: left; background: #fff; border: 1px solid #ddd; border-radius: 6px;
+    padding: 10px 12px; cursor: pointer; font: inherit; color: inherit;
+    display: flex; flex-direction: column; gap: 6px; }
+.pc-card:hover { border-color: #485ba6; box-shadow: 0 1px 4px rgba(0, 0, 0, .08); }
+.pc-card-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; flex-wrap: wrap; }
+.pc-card-head h4 { margin: 0; font-size: 1em; }
+.pc-desc { margin: 0; color: #555; font-size: .85em; line-height: 1.4;
+    display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+
+.pc-badges { display: flex; flex-wrap: wrap; gap: 4px; }
+.pc-source { background: #fde68a !important; color: #7c2d12 !important; }
+.pc-filter { background: #dbeafe !important; color: #1e3a8a !important; }
+.pc-approx { background: #fecaca !important; color: #7f1d1d !important; }
+.pc-maybe { background: #fde68a !important; color: #78350f !important; }
+
+/* prerequisite chain + chips */
+.pc-chain { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin: 6px 0 12px; }
+.pc-step, .pc-chip { font: inherit; font-size: .85em; padding: 3px 9px; border-radius: 12px;
+    border: 1px solid #ccced8; background: #f3f4f8; cursor: pointer; color: #223; }
+.pc-step.pc-src, .pc-chip.pc-src { background: #fde68a; border-color: #d97706; color: #7c2d12; }
+.pc-step.pc-group { cursor: help; }
+.pc-step.pc-groupnode { background: #dbeafe; border-color: #2563eb; color: #1e3a8a; }
+.pc-step.pc-current { background: #485ba6; border-color: #485ba6; color: #fff; cursor: default; font-weight: bold; }
+.pc-chip.pc-next { background: #dcfce7; border-color: #16a34a; color: #14532d; }
+.pc-chip.pc-req { background: #eef2ff; border-color: #c7d2fe; color: #3730a3; cursor: default; }
+.pc-chip.pc-uncertain { border-style: dashed; }
+.pc-q { color: #b45309; font-weight: bold; }
+.pc-step:hover, .pc-chip:hover { border-color: #222; }
+.pc-chip.pc-req:hover { border-color: #c7d2fe; }
+.pc-step.pc-current:hover { border-color: #485ba6; }
+.pc-arrow { color: #999; }
+
+/* data-source routes -- "where to start", grouped by the step you run first */
+.pc-route { margin: 4px 0 12px; }
+.pc-route-label { margin: 8px 0 4px; font-size: .85em; color: #444; }
+.pc-route-step { cursor: pointer; color: #1e3a8a; font-weight: bold; }
+.pc-route-step:hover { text-decoration: underline; }
+.pc-route-direct { font-weight: bold; color: #444; }
+.pc-more { font: inherit; font-size: .8em; border: none; background: none; color: #485ba6;
+    cursor: pointer; padding: 3px 6px; align-self: center; }
+.pc-more:hover { text-decoration: underline; }
+
+.pc-chips { display: flex; flex-wrap: wrap; gap: 5px; margin: 4px 0 10px; }
+.pc-sub { margin: 12px 0 4px; color: #666; font-size: .78em; text-transform: uppercase; letter-spacing: .04em; }
+.pc-collapse { margin: 8px 0 4px; }
+summary.pc-sub { cursor: pointer; }
+summary.pc-sub:hover { color: #485ba6; }
+.pc-cond { color: #6b7280; font-size: .85em; font-style: italic; margin: 4px 0; }
+.pc-note { color: #b91c1c; font-size: .85em; margin: 4px 0; }
+.pc-muted { color: #888; }
+.pc-spec { background: #f6f7f9; border: 1px solid #e5e7eb; border-radius: 6px; padding: 8px;
+    font-size: .8em; white-space: pre-wrap; overflow: auto; }

--- a/webtool/static/js/processor-catalogue.js
+++ b/webtool/static/js/processor-catalogue.js
@@ -1,29 +1,35 @@
 /* Processor catalogue (prototype).
  *
  * A thin reactive client over the /api/processor-map/* endpoints: browse/search
- * processors, then open one to see "how to run this" (what dataset it accepts and
- * concrete ways to get there from a data source) and "what can run on this" (the
+ * processors, then open one to see "how to run this" (the dataset it needs and the
+ * sensible ways to get there from a data source) and "what can run on this" (the
  * follow-up processors and filters its output unlocks). Holds no compatibility
- * logic itself -- that all lives in common/lib/processor_map.py.
+ * logic itself -- that all lives in common/lib/processor_map.py; this file only
+ * fetches what that computed and lays it out.
  */
 (function () {
   "use strict";
 
   const API = "/api/processor-map";
-  let CATALOGUE = [];
-  const TITLE = {};
+  let CATALOGUE = [];   // every processor, as returned by the catalogue endpoint
+  const TITLE = {};     // processor type -> display title, so links can show names not ids
 
+  // small text helpers: escape for HTML, look up a title by type, join a value for display
   const esc = s => String(s == null ? "" : s).replace(/[&<>"]/g,
     c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
   const titleOf = t => TITLE[t] || t;
   const listOf = v => Array.isArray(v) ? v.join(", ") : String(v);
 
+  // Fetch one of the map's JSON endpoints. Throws on an HTTP error so the caller can
+  // show a message rather than rendering half a page.
   async function getJSON(url) {
     const response = await fetch(url);
     if (!response.ok) throw new Error("HTTP " + response.status);
     return response.json();
   }
 
+  // On load: pull the whole catalogue once, remember every title, wire up the search
+  // box and category dropdown, and draw the list. Everything after this is redrawing.
   async function init() {
     let data;
     try {
@@ -41,6 +47,7 @@
     renderCatalogue();
   }
 
+  // Fill the category dropdown with the categories actually present in the catalogue.
   function populateCategories() {
     const categories = [...new Set(CATALOGUE.map(p => p.category || "(uncategorised)"))].sort();
     const select = document.getElementById("pc-category");
@@ -54,6 +61,9 @@
 
   // --- catalogue (browse / search) ---
 
+  // Draw the browse list: keep the processors matching the search box and the selected
+  // category, group them by category, and render a card for each. Also updates the
+  // "N of M" count and re-attaches the click handler that opens a card's detail.
   function renderCatalogue() {
     const query = document.getElementById("pc-search").value.trim().toLowerCase();
     const category = document.getElementById("pc-category").value;
@@ -76,6 +86,8 @@
     section.querySelectorAll(".pc-card").forEach(el => el.addEventListener("click", () => showDetail(el.dataset.type)));
   }
 
+  // One processor as a clickable browse card: title, a badge or two (data source /
+  // filter / keeps a custom compatibility override), and its description.
   function card(p) {
     const badges = [
       p.is_datasource ? '<span class="inline-label property-badge pc-source">data source</span>' : "",
@@ -90,6 +102,9 @@
 
   // --- detail ("how to run this" / "what can run on this") ---
 
+  // Load one processor's full detail from the API and render it into the top pane. Then
+  // wire the interactive bits: every element carrying a data-type is a link that opens
+  // that processor, and each "+N more" button reveals the sources its group was hiding.
   async function showDetail(type) {
     const body = document.getElementById("pc-detail-body");
     body.innerHTML = '<p class="banner">Loading…</p>';
@@ -116,8 +131,9 @@
       }));
   }
 
-  // a row of clickable chips linking to other processors. `steps` are objects
-  // carrying at least a `type`; a "maybe" certainty is shown as an unconfirmed chip.
+  // A row of clickable chips, one per processor. A link the map is only unsure about
+  // ("maybe") is marked with a "?" -- the specs can't promise it applies, only that it
+  // might, so it is shown but flagged rather than hidden.
   function chipRow(steps, cls) {
     if (!steps || !steps.length) return '<span class="pc-muted">none</span>';
     return '<div class="pc-chips">' + steps.map(step => {
@@ -129,7 +145,8 @@
     }).join("") + "</div>";
   }
 
-  // the declared requirement (from describe_spec) as plain, non-clickable chips
+  // Turns each condition a processor declares (the keys of the map's "requirement")
+  // into a short plain phrase. A key not listed here falls back to a generic "key: value".
   const REQ_LABEL = {
     types: v => `type is ${listOf(v)}`,
     type_prefixes: v => `type starts with ${listOf(v)}`,
@@ -147,6 +164,8 @@
     required_packages: v => `package: ${listOf(v)}`,
   };
 
+  // The dataset conditions a processor needs, as plain non-clickable chips; says
+  // "almost any dataset" when it declares none.
   function requirementHtml(requirement) {
     const keys = Object.keys(requirement || {});
     if (!keys.length) return '<p class="pc-muted">Runs on almost any dataset.</p>';
@@ -158,7 +177,9 @@
     return `<div class="pc-chips">${chips}</div>`;
   }
 
-  // clickable data-source chips, capped with a "+N more" reveal when the group is large
+  // Clickable data-source chips. A long group is capped and the overflow hidden behind a
+  // "+N more" button (revealed by the handler in showDetail), so one big group can't
+  // swamp the panel.
   function sourceChips(sources) {
     const CAP = 12;
     const chip = t => `<button class="pc-chip pc-src" data-type="${esc(t)}">${esc(titleOf(t))}</button>`;
@@ -169,9 +190,12 @@
       + `<button class="pc-more" type="button">+${sources.length - CAP} more</button></div>`;
   }
 
-  // "Where to start": the data sources, grouped by the route to reach this processor.
-  // Sources you can run it on directly come first; the rest are grouped by the one step
-  // you run first (so a route shared by many sources is shown once, not once per source).
+  // The sensible ways to start, grouped by route. Each group is "run this one processor,
+  // then this" (or "run it straight away"), with the data sources that fit that route
+  // listed under it -- so a route many sources share is shown once, not once per source.
+  // Only short routes appear: the API caps a route at one step, because reaching a
+  // processor through many hops is rarely the sensible way in. Longer paths are still
+  // there to find by opening the processors in a chain.
   function dataSourcesHtml(points, currentTitle) {
     if (!points || !points.length) return "";
     const groups = new Map();  // route key -> {then: [step], sources: [type]}
@@ -181,6 +205,7 @@
       if (!groups.has(key)) groups.set(key, { then, sources: [] });
       groups.get(key).sources.push(sp.datasource);
     });
+    // direct routes ("run it straight away") first, then the one-step routes
     const entries = [...groups.entries()].sort((a, b) =>
       a[0] === "__direct__" ? -1 : b[0] === "__direct__" ? 1 : a[0].localeCompare(b[0]));
 
@@ -193,19 +218,29 @@
       const sources = group.sources.slice().sort((a, b) => titleOf(a).localeCompare(titleOf(b)));
       return `<div class="pc-route"><p class="pc-route-label">${label}</p>${sourceChips(sources)}</div>`;
     }).join("");
-    return '<p class="pc-sub">Data sources — where to start</p>' + rows;
+    const note = '<p class="pc-cond">The most direct routes only. A processor can often be '
+      + 'reached through longer chains as well — follow those by opening a processor to see what '
+      + 'runs on its output, or from the "run processor" menu on a dataset.</p>';
+    return '<p class="pc-sub">Data sources — sensible ways to start</p>' + rows + note;
   }
 
+  // A large collapsible block in the detail pane (How to run / What can run on this /
+  // Compatibility). `open` decides whether it starts expanded.
   function section(title, open, inner) {
     return `<details class="pc-section"${open ? " open" : ""}><summary>${esc(title)}</summary><div class="pc-section-body">${inner}</div></details>`;
   }
 
-  // a collapsible sub-heading (styled like a pc-sub label), collapsed by default
+  // A smaller collapsible sub-heading inside a block, with a count, collapsed by default
+  // -- for a secondary list that would otherwise crowd out the main point.
   function subCollapse(title, count, inner) {
     const badge = count != null ? ` <span class="pc-muted">(${count})</span>` : "";
     return `<details class="pc-collapse"><summary class="pc-sub">${esc(title)}${badge}</summary>${inner}</details>`;
   }
 
+  // The "How to run" block. A filter or a data source doesn't "run on" anything, so each
+  // gets a one-line explanation. Any other processor leads with the sensible data sources
+  // to start from (the main takeaway), then the dataset it needs, then -- collapsed --
+  // the processors whose output it takes directly, then any caveats.
   function howToRunHtml(info) {
     const htr = info.how_to_run || {};
 
@@ -218,7 +253,6 @@
         .map(note => `<p>${esc(note)}</p>`).join("");
 
     const accepts = htr.accepts || {};
-    // data sources first -- the main takeaway: where can I start to reach this?
     let how = dataSourcesHtml(htr.starting_points, info.title || info.type);
     how += '<p class="pc-sub">Needs a dataset that…</p>' + requirementHtml(accepts.requirement);
     if ((accepts.from_processors || []).length)
@@ -228,6 +262,9 @@
     return how;
   }
 
+  // The "What can run on this" block: the curated "suggested next" first, then filters
+  // (kept apart -- they narrow the data without changing its format), then everything
+  // else grouped by category. A closing note appears for filters (see the API).
   function followupsHtml(info) {
     const fu = info.followups || {};
     let next = "";
@@ -243,6 +280,9 @@
     return next || '<p class="pc-muted">Nothing runs on this output.</p>';
   }
 
+  // Assemble the whole detail pane for one processor: heading and badges, a short
+  // metadata list (type / category / what it produces / description), then the three
+  // blocks. "Produces" is left out when the output shape didn't pin down a format.
   function detailHtml(info) {
     const shape = info.output_shape || {};
 

--- a/webtool/static/js/processor-catalogue.js
+++ b/webtool/static/js/processor-catalogue.js
@@ -1,0 +1,278 @@
+/* Processor catalogue (prototype).
+ *
+ * A thin reactive client over the /api/processor-map/* endpoints: browse/search
+ * processors, then open one to see "how to run this" (what dataset it accepts and
+ * concrete ways to get there from a data source) and "what can run on this" (the
+ * follow-up processors and filters its output unlocks). Holds no compatibility
+ * logic itself -- that all lives in common/lib/processor_map.py.
+ */
+(function () {
+  "use strict";
+
+  const API = "/api/processor-map";
+  let CATALOGUE = [];
+  const TITLE = {};
+
+  const esc = s => String(s == null ? "" : s).replace(/[&<>"]/g,
+    c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+  const titleOf = t => TITLE[t] || t;
+  const listOf = v => Array.isArray(v) ? v.join(", ") : String(v);
+
+  async function getJSON(url) {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error("HTTP " + response.status);
+    return response.json();
+  }
+
+  async function init() {
+    let data;
+    try {
+      data = await getJSON(`${API}/catalogue`);
+    } catch (e) {
+      document.getElementById("pc-loading").textContent = "Could not load processors.";
+      return;
+    }
+    CATALOGUE = (data.processors || []).slice().sort((a, b) => (a.title || a.type).localeCompare(b.title || b.type));
+    CATALOGUE.forEach(p => { TITLE[p.type] = p.title || p.type; });
+
+    populateCategories();
+    document.getElementById("pc-search").addEventListener("input", renderCatalogue);
+    document.getElementById("pc-category").addEventListener("change", renderCatalogue);
+    renderCatalogue();
+  }
+
+  function populateCategories() {
+    const categories = [...new Set(CATALOGUE.map(p => p.category || "(uncategorised)"))].sort();
+    const select = document.getElementById("pc-category");
+    categories.forEach(category => {
+      const option = document.createElement("option");
+      option.value = category;
+      option.textContent = category;
+      select.appendChild(option);
+    });
+  }
+
+  // --- catalogue (browse / search) ---
+
+  function renderCatalogue() {
+    const query = document.getElementById("pc-search").value.trim().toLowerCase();
+    const category = document.getElementById("pc-category").value;
+
+    let items = CATALOGUE;
+    if (category) items = items.filter(p => (p.category || "(uncategorised)") === category);
+    if (query) items = items.filter(p =>
+      `${p.type} ${p.title || ""} ${p.category || ""} ${p.description || ""}`.toLowerCase().includes(query));
+
+    const groups = {};
+    items.forEach(p => { const c = p.category || "(uncategorised)"; (groups[c] = groups[c] || []).push(p); });
+
+    const section = document.getElementById("pc-catalogue");
+    section.innerHTML = items.length
+      ? Object.keys(groups).sort().map(c =>
+          `<div class="pc-cat"><h2><span>${esc(c)}</span></h2><div class="pc-grid">${groups[c].map(card).join("")}</div></div>`
+        ).join("")
+      : '<p class="banner">No processors match your search.</p>';
+    document.getElementById("pc-count").textContent = `${items.length} of ${CATALOGUE.length}`;
+    section.querySelectorAll(".pc-card").forEach(el => el.addEventListener("click", () => showDetail(el.dataset.type)));
+  }
+
+  function card(p) {
+    const badges = [
+      p.is_datasource ? '<span class="inline-label property-badge pc-source">data source</span>' : "",
+      p.is_filter ? '<span class="inline-label property-badge pc-filter">filter</span>' : "",
+      p.has_override ? '<span class="inline-label property-badge pc-approx">override</span>' : ""
+    ].join("");
+    return `<button class="pc-card" data-type="${esc(p.type)}">
+      <div class="pc-card-head"><h4>${esc(p.title || p.type)}</h4><span class="pc-badges">${badges}</span></div>
+      <p class="pc-desc">${esc(p.description || "")}</p>
+    </button>`;
+  }
+
+  // --- detail ("how to run this" / "what can run on this") ---
+
+  async function showDetail(type) {
+    const body = document.getElementById("pc-detail-body");
+    body.innerHTML = '<p class="banner">Loading…</p>';
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    let info;
+    try {
+      info = await getJSON(`${API}/processor/${encodeURIComponent(type)}`);
+    } catch (e) {
+      body.innerHTML = '<p class="banner">Could not load this processor.</p>';
+      return;
+    }
+    if (!info || !info.type) {
+      body.innerHTML = '<p class="banner">Processor not found.</p>';
+      return;
+    }
+    body.innerHTML = detailHtml(info);
+    body.querySelectorAll("[data-type]").forEach(el =>
+      el.addEventListener("click", e => { e.stopPropagation(); showDetail(el.dataset.type); }));
+    body.querySelectorAll(".pc-more").forEach(el =>
+      el.addEventListener("click", () => {
+        const hidden = el.previousElementSibling;   // the wrap of overflow chips
+        if (hidden) hidden.hidden = false;
+        el.remove();
+      }));
+  }
+
+  // a row of clickable chips linking to other processors. `steps` are objects
+  // carrying at least a `type`; a "maybe" certainty is shown as an unconfirmed chip.
+  function chipRow(steps, cls) {
+    if (!steps || !steps.length) return '<span class="pc-muted">none</span>';
+    return '<div class="pc-chips">' + steps.map(step => {
+      const maybe = step.certainty === "maybe";
+      const marker = maybe ? ' <span class="pc-q">?</span>' : "";
+      const tip = maybe ? ' title="might apply — not confirmed from the specs alone"' : "";
+      return `<button class="pc-chip ${cls || ""}${maybe ? " pc-uncertain" : ""}" data-type="${esc(step.type)}"${tip}>`
+        + `${esc(titleOf(step.type))}${marker}</button>`;
+    }).join("") + "</div>";
+  }
+
+  // the declared requirement (from describe_spec) as plain, non-clickable chips
+  const REQ_LABEL = {
+    types: v => `type is ${listOf(v)}`,
+    type_prefixes: v => `type starts with ${listOf(v)}`,
+    media_types: v => `media is ${listOf(v)}`,
+    datasources: v => `from data source ${listOf(v)}`,
+    is_collector: () => "must be a data source",
+    extensions: v => `format is ${listOf(v)}`,
+    top_dataset_only: () => "top-level dataset only",
+    child_only: () => "must be a derived dataset",
+    excluded_types: v => `not ${listOf(v)}`,
+    rankable: v => v ? "must be rankable" : "must not be rankable",
+    requires_all_columns: v => `has columns ${listOf(v)}`,
+    requires_any_columns: v => `has a column ${listOf(v)}`,
+    required_settings: v => `setting: ${listOf(v)}`,
+    required_packages: v => `package: ${listOf(v)}`,
+  };
+
+  function requirementHtml(requirement) {
+    const keys = Object.keys(requirement || {});
+    if (!keys.length) return '<p class="pc-muted">Runs on almost any dataset.</p>';
+    const chips = keys.map(key => {
+      const fmt = REQ_LABEL[key];
+      const text = fmt ? fmt(requirement[key]) : `${key.replace(/_/g, " ")}: ${listOf(requirement[key])}`;
+      return `<span class="pc-chip pc-req">${esc(text)}</span>`;
+    }).join("");
+    return `<div class="pc-chips">${chips}</div>`;
+  }
+
+  // clickable data-source chips, capped with a "+N more" reveal when the group is large
+  function sourceChips(sources) {
+    const CAP = 12;
+    const chip = t => `<button class="pc-chip pc-src" data-type="${esc(t)}">${esc(titleOf(t))}</button>`;
+    if (sources.length <= CAP) return `<div class="pc-chips">${sources.map(chip).join("")}</div>`;
+    const shown = sources.slice(0, CAP).map(chip).join("");
+    const rest = sources.slice(CAP).map(chip).join("");
+    return `<div class="pc-chips">${shown}<span class="pc-more-wrap" hidden>${rest}</span>`
+      + `<button class="pc-more" type="button">+${sources.length - CAP} more</button></div>`;
+  }
+
+  // "Where to start": the data sources, grouped by the route to reach this processor.
+  // Sources you can run it on directly come first; the rest are grouped by the one step
+  // you run first (so a route shared by many sources is shown once, not once per source).
+  function dataSourcesHtml(points, currentTitle) {
+    if (!points || !points.length) return "";
+    const groups = new Map();  // route key -> {then: [step], sources: [type]}
+    points.forEach(sp => {
+      const then = sp.then || [];
+      const key = then.map(step => step.type).join(">") || "__direct__";
+      if (!groups.has(key)) groups.set(key, { then, sources: [] });
+      groups.get(key).sources.push(sp.datasource);
+    });
+    const entries = [...groups.entries()].sort((a, b) =>
+      a[0] === "__direct__" ? -1 : b[0] === "__direct__" ? 1 : a[0].localeCompare(b[0]));
+
+    const rows = entries.map(([key, group]) => {
+      const label = key === "__direct__"
+        ? `<span class="pc-route-direct">Run directly → ${esc(currentTitle)}</span>`
+        : "via " + group.then.map(step =>
+            `<span class="pc-route-step" data-type="${esc(step.type)}">${esc(step.title)}</span>`).join(" → ")
+          + ` → ${esc(currentTitle)}`;
+      const sources = group.sources.slice().sort((a, b) => titleOf(a).localeCompare(titleOf(b)));
+      return `<div class="pc-route"><p class="pc-route-label">${label}</p>${sourceChips(sources)}</div>`;
+    }).join("");
+    return '<p class="pc-sub">Data sources — where to start</p>' + rows;
+  }
+
+  function section(title, open, inner) {
+    return `<details class="pc-section"${open ? " open" : ""}><summary>${esc(title)}</summary><div class="pc-section-body">${inner}</div></details>`;
+  }
+
+  // a collapsible sub-heading (styled like a pc-sub label), collapsed by default
+  function subCollapse(title, count, inner) {
+    const badge = count != null ? ` <span class="pc-muted">(${count})</span>` : "";
+    return `<details class="pc-collapse"><summary class="pc-sub">${esc(title)}${badge}</summary>${inner}</details>`;
+  }
+
+  function howToRunHtml(info) {
+    const htr = info.how_to_run || {};
+
+    if (htr.is_filter || info.is_filter)
+      return (htr.notes || ["This is a filter: it runs on almost any dataset and keeps its format."])
+        .map(note => `<p>${esc(note)}</p>`).join("");
+
+    if (info.is_datasource)
+      return (htr.notes || ["This is a data source: run it to start collecting data."])
+        .map(note => `<p>${esc(note)}</p>`).join("");
+
+    const accepts = htr.accepts || {};
+    // data sources first -- the main takeaway: where can I start to reach this?
+    let how = dataSourcesHtml(htr.starting_points, info.title || info.type);
+    how += '<p class="pc-sub">Needs a dataset that…</p>' + requirementHtml(accepts.requirement);
+    if ((accepts.from_processors || []).length)
+      how += subCollapse("Runs on the output of", accepts.from_processors.length,
+                         chipRow(accepts.from_processors, ""));
+    (htr.notes || []).forEach(note => { how += `<p class="pc-cond">${esc(note)}</p>`; });
+    return how;
+  }
+
+  function followupsHtml(info) {
+    const fu = info.followups || {};
+    let next = "";
+    if ((fu.preferred || []).length)
+      next += '<p class="pc-sub">Suggested next</p>' + chipRow(fu.preferred, "pc-next");
+    if ((fu.filters || []).length)
+      next += '<p class="pc-sub">Filters — narrow the data, keep the format</p>' + chipRow(fu.filters, "pc-next");
+    const others = fu.others_by_category || {};
+    Object.keys(others).sort().forEach(category => {
+      next += `<p class="pc-sub">${esc(category)}</p>` + chipRow(others[category], "pc-next");
+    });
+    if (fu.note) next += `<p class="pc-cond">${esc(fu.note)}</p>`;
+    return next || '<p class="pc-muted">Nothing runs on this output.</p>';
+  }
+
+  function detailHtml(info) {
+    const shape = info.output_shape || {};
+
+    const badges = [
+      info.is_datasource ? '<span class="inline-label property-badge pc-source">data source</span>' : "",
+      info.is_filter ? '<span class="inline-label property-badge pc-filter">filter</span>' : "",
+      info.has_override ? '<span class="inline-label property-badge pc-approx">override — approximate</span>' : "",
+      info.requires_dataset_result_file ? '<span class="inline-label property-badge pc-maybe">needs dataset data</span>' : ""
+    ].join("");
+
+    const spec = info.compatibility
+      ? `<pre class="pc-spec">${esc(JSON.stringify(info.compatibility, null, 2))}</pre>`
+      : '<p class="pc-muted">No declared compatibility (defaults to top-level datasets).</p>';
+    const produces = [shape.extension, shape.media_type].filter(v => v && v !== "unknown").join(" · ");
+
+    return `
+      <h2><span>${esc(info.title || info.type)}</span></h2>
+      <p class="pc-badges">${badges}</p>
+      <dl class="metadata-wrapper">
+        <div class="fullwidth"><dt>Type</dt><dd><code>${esc(info.type)}</code></dd></div>
+        ${info.category ? `<div class="fullwidth"><dt>Category</dt><dd>${esc(info.category)}</dd></div>` : ""}
+        ${produces ? `<div class="fullwidth"><dt>Produces</dt><dd>${esc(produces)}</dd></div>` : ""}
+        ${info.description ? `<div class="fullwidth"><dt>About</dt><dd>${esc(info.description)}</dd></div>` : ""}
+      </dl>
+      ${section("How to run", true, howToRunHtml(info))}
+      ${section("What can run on this", true, followupsHtml(info))}
+      ${section("Compatibility (declared)", false, spec)}
+    `;
+  }
+
+  if (document.readyState !== "loading") init();
+  else document.addEventListener("DOMContentLoaded", init);
+})();

--- a/webtool/static/js/processor-catalogue.js
+++ b/webtool/static/js/processor-catalogue.js
@@ -103,8 +103,7 @@
   // --- detail ("how to run this" / "what can run on this") ---
 
   // Load one processor's full detail from the API and render it into the top pane. Then
-  // wire the interactive bits: every element carrying a data-type is a link that opens
-  // that processor, and each "+N more" button reveals the sources its group was hiding.
+  // wire the links: every element carrying a data-type opens that processor when clicked.
   async function showDetail(type) {
     const body = document.getElementById("pc-detail-body");
     body.innerHTML = '<p class="banner">Loading…</p>';
@@ -123,12 +122,6 @@
     body.innerHTML = detailHtml(info);
     body.querySelectorAll("[data-type]").forEach(el =>
       el.addEventListener("click", e => { e.stopPropagation(); showDetail(el.dataset.type); }));
-    body.querySelectorAll(".pc-more").forEach(el =>
-      el.addEventListener("click", () => {
-        const hidden = el.previousElementSibling;   // the wrap of overflow chips
-        if (hidden) hidden.hidden = false;
-        el.remove();
-      }));
   }
 
   // A row of clickable chips, one per processor. A link the map is only unsure about
@@ -177,51 +170,30 @@
     return `<div class="pc-chips">${chips}</div>`;
   }
 
-  // Clickable data-source chips. A long group is capped and the overflow hidden behind a
-  // "+N more" button (revealed by the handler in showDetail), so one big group can't
-  // swamp the panel.
-  function sourceChips(sources) {
-    const CAP = 12;
-    const chip = t => `<button class="pc-chip pc-src" data-type="${esc(t)}">${esc(titleOf(t))}</button>`;
-    if (sources.length <= CAP) return `<div class="pc-chips">${sources.map(chip).join("")}</div>`;
-    const shown = sources.slice(0, CAP).map(chip).join("");
-    const rest = sources.slice(CAP).map(chip).join("");
-    return `<div class="pc-chips">${shown}<span class="pc-more-wrap" hidden>${rest}</span>`
-      + `<button class="pc-more" type="button">+${sources.length - CAP} more</button></div>`;
-  }
+  // A few concrete example paths, each drawn as a chain: data source → steps → this. The
+  // API returns the shortest few (one per distinct recipe), so these read as "here are a
+  // couple of ways it's done", not an exhaustive list. Empty means nothing reaches this by
+  // confirmed steps -- flagged, as that usually points at a spec gap.
+  function examplesHtml(examples, currentTitle) {
+    const heading = '<p class="pc-sub">Example ways to reach this</p>';
+    if (!examples || !examples.length)
+      return heading + '<p class="pc-cond">No data source reaches this by confirmed steps — likely an '
+        + 'over-strict requirement or a missing link between processors.</p>';
 
-  // The sensible ways to start, grouped by route. Each group is "run this one processor,
-  // then this" (or "run it straight away"), with the data sources that fit that route
-  // listed under it -- so a route many sources share is shown once, not once per source.
-  // Only short routes appear: the API caps a route at one step, because reaching a
-  // processor through many hops is rarely the sensible way in. Longer paths are still
-  // there to find by opening the processors in a chain.
-  function dataSourcesHtml(points, currentTitle) {
-    if (!points || !points.length) return "";
-    const groups = new Map();  // route key -> {then: [step], sources: [type]}
-    points.forEach(sp => {
-      const then = sp.then || [];
-      const key = then.map(step => step.type).join(">") || "__direct__";
-      if (!groups.has(key)) groups.set(key, { then, sources: [] });
-      groups.get(key).sources.push(sp.datasource);
-    });
-    // direct routes ("run it straight away") first, then the one-step routes
-    const entries = [...groups.entries()].sort((a, b) =>
-      a[0] === "__direct__" ? -1 : b[0] === "__direct__" ? 1 : a[0].localeCompare(b[0]));
-
-    const rows = entries.map(([key, group]) => {
-      const label = key === "__direct__"
-        ? `<span class="pc-route-direct">Run directly → ${esc(currentTitle)}</span>`
-        : "via " + group.then.map(step =>
-            `<span class="pc-route-step" data-type="${esc(step.type)}">${esc(step.title)}</span>`).join(" → ")
-          + ` → ${esc(currentTitle)}`;
-      const sources = group.sources.slice().sort((a, b) => titleOf(a).localeCompare(titleOf(b)));
-      return `<div class="pc-route"><p class="pc-route-label">${label}</p>${sourceChips(sources)}</div>`;
+    const chains = examples.map(example => {
+      const parts = [`<span class="pc-step pc-src" data-type="${esc(example.datasource)}">${esc(example.title)}</span>`];
+      (example.then || []).forEach(step => {
+        parts.push('<span class="pc-arrow">→</span>');
+        parts.push(`<span class="pc-step" data-type="${esc(step.type)}">${esc(step.title)}</span>`);
+      });
+      parts.push('<span class="pc-arrow">→</span>');
+      parts.push(`<span class="pc-step pc-current">${esc(currentTitle)}</span>`);
+      return `<div class="pc-chain">${parts.join("")}</div>`;
     }).join("");
-    const note = '<p class="pc-cond">The most direct routes only. A processor can often be '
-      + 'reached through longer chains as well — follow those by opening a processor to see what '
-      + 'runs on its output, or from the "run processor" menu on a dataset.</p>';
-    return '<p class="pc-sub">Data sources — sensible ways to start</p>' + rows + note;
+
+    const note = '<p class="pc-cond">A few of the shortest ways in — examples, not the only routes. '
+      + 'Most processors can be reached other ways too; click any step to explore from there.</p>';
+    return heading + chains + note;
   }
 
   // A large collapsible block in the detail pane (How to run / What can run on this /
@@ -238,9 +210,9 @@
   }
 
   // The "How to run" block. A filter or a data source doesn't "run on" anything, so each
-  // gets a one-line explanation. Any other processor leads with the sensible data sources
-  // to start from (the main takeaway), then the dataset it needs, then -- collapsed --
-  // the processors whose output it takes directly, then any caveats.
+  // gets a one-line explanation. Any other processor leads with a few example paths to
+  // reach it, then the dataset it needs, then -- collapsed -- the processors whose output
+  // it takes directly, then any caveats.
   function howToRunHtml(info) {
     const htr = info.how_to_run || {};
 
@@ -253,7 +225,7 @@
         .map(note => `<p>${esc(note)}</p>`).join("");
 
     const accepts = htr.accepts || {};
-    let how = dataSourcesHtml(htr.starting_points, info.title || info.type);
+    let how = examplesHtml(htr.examples, info.title || info.type);
     how += '<p class="pc-sub">Needs a dataset that…</p>' + requirementHtml(accepts.requirement);
     if ((accepts.from_processors || []).length)
       how += subCollapse("Runs on the output of", accepts.from_processors.length,

--- a/webtool/templates/processor-catalogue.html
+++ b/webtool/templates/processor-catalogue.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+
+{% block title %}Processor catalogue{% endblock %}
+{% block body_class %}plain-page processor-catalogue{% endblock %}
+{% block breadcrumbs %}{% set navigation.current = "datasources" %}{% endblock %}
+
+{% block body %}
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/processor-catalogue.css') }}">
+
+<article>
+    <section id="pc-detail">
+        <div id="pc-detail-body">
+            <p class="pc-placeholder">Select a processor below to see how to run it and what it unlocks.</p>
+        </div>
+    </section>
+
+    <nav class="view-controls block" id="pc-controls">
+        <h2 class="pc-browse-title">Browse processors</h2>
+        <form onsubmit="return false">
+            <ul>
+                <li><input id="pc-search" aria-label="Search processors" placeholder="Search processors…" autocomplete="off" spellcheck="false"></li>
+                <li>
+                    <select id="pc-category" aria-label="Filter by category">
+                        <option value="">All categories</option>
+                    </select>
+                </li>
+                <li><span id="pc-count" class="pc-count"></span></li>
+            </ul>
+        </form>
+    </nav>
+
+    <section id="pc-catalogue">
+        <p class="banner" id="pc-loading">Loading processors…</p>
+    </section>
+</article>
+
+<script type="text/javascript" src="{{ url_for('static', filename='js/processor-catalogue.js') }}"></script>
+{% endblock %}

--- a/webtool/views/api_processor_map.py
+++ b/webtool/views/api_processor_map.py
@@ -1,0 +1,82 @@
+"""
+Processor map API.
+
+Thin JSON endpoints over `common.lib.processor_map` -- each just builds the
+ProcessorMap and calls one method, so the data layer stays in common/lib and any
+UI can be built against these without touching it.
+
+Login-gated. Demonstrates what the declarative Compatibility specs make computable
+(search, "how to run this", shape buckets, follow-ups) with no datasets and no
+database.
+"""
+from flask import Blueprint, current_app, jsonify, request, g
+from flask_login import login_required
+
+from webtool.lib.helpers import error
+from common.lib.processor_map import ProcessorMap
+
+component = Blueprint("processormap", __name__)
+api_ratelimit = current_app.limiter.shared_limit("3 per second", scope="api")
+
+# Cache the built map per modules object. `g.modules` (app.fourcat_modules) is a
+# single process-global, replaced only on a full reload, so its identity is a safe
+# cache key -- a new identity forces a rebuild.
+# NOTE: config is NOT part of the key: the ProcessorMap does not gate edges on
+# per-user config today. Per-user maps would need the config (or user) in the key.
+_MAP_CACHE = {}  # id(modules) -> (modules, ProcessorMap)
+
+
+def _processor_map():
+    modules = g.modules
+    cached = _MAP_CACHE.get(id(modules))
+    if cached is None or cached[0] is not modules:
+        _MAP_CACHE.clear()
+        _MAP_CACHE[id(modules)] = (modules, ProcessorMap(modules, g.config, logger=g.log))
+    return _MAP_CACHE[id(modules)][1]
+
+
+@component.route("/api/processor-map/catalogue")
+@api_ratelimit
+@login_required
+def processor_map_catalogue():
+    """Every processor with display metadata and flags (the browse surface)."""
+    return jsonify({"processors": _processor_map().catalogue()})
+
+
+@component.route("/api/processor-map/categories")
+@api_ratelimit
+@login_required
+def processor_map_categories():
+    """{category: [types]} for grouped browsing."""
+    return jsonify(_processor_map().categories())
+
+
+@component.route("/api/processor-map/search")
+@api_ratelimit
+@login_required
+def processor_map_search():
+    """Find processors by a substring of type/title/category/description."""
+    query = request.args.get("q", "")[:200]  # substring search
+    return jsonify({"query": query, "results": _processor_map().search(query)})
+
+
+@component.route("/api/processor-map/processor/<string:processor_type>")
+@api_ratelimit
+@login_required
+def processor_map_node(processor_type):
+    """
+    One processor in full: metadata, declared compatibility, how-to-run (the
+    prerequisite chain + datasources + shape buckets) and available follow-ups.
+    """
+    info = _processor_map().processor(processor_type)
+    if info is None:
+        return error(404, message="Processor '%s' does not exist" % processor_type)
+    return jsonify(info)
+
+
+@component.route("/api/processor-map/graph")
+@api_ratelimit
+@login_required
+def processor_map_graph():
+    """The whole graph as {nodes, edges} -- low-level/debug backbone."""
+    return jsonify(_processor_map().graph())

--- a/webtool/views/views_processor_map.py
+++ b/webtool/views/views_processor_map.py
@@ -1,0 +1,20 @@
+"""
+Processor catalogue page (proof of concept).
+
+A thin, unlinked template endpoint that renders the catalogue. It holds no query
+logic of its own -- the page fetches everything from the JSON API in
+`api_processor_map`. Keeping the presentation here and the data there means this
+layer can be restyled, server-rendered, or replaced by a reactive frontend
+without touching the API.
+"""
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+component = Blueprint("processormapview", __name__)
+
+
+@component.route("/processor-catalogue")
+@login_required
+def processor_catalogue_page():
+    """Render the processor catalogue: browse/search, then "how to run this"."""
+    return render_template("processor-catalogue.html")


### PR DESCRIPTION
I changed tack here. The processor map I demoed was annoyingly wrong in places. I made it more accurate in determining "yes", "no", or importantly "maybe". Then everything was "maybe" and I could not reasonably infer truth from Processor classes alone.

I added an Output class which enables a much more powerful map that ties directly in with the Compatibility object. Compatibility can now `check` either an actual `DataSet` or a declared `Output`. For a DataSet, the result is either "yes" or "no"; only `Output` can return "maybe". We now also have sensible Output subclasses with default and they can easily be overridden when declared with actually declaring them (see `output.py`). I also created tests to confirm the `Output` has identical information to the Processor's declared attributes (e.g. `extension` or `media_type`). A logical follow on would be to use the Output class directly to replace those (e.g. use `processor.output.extension` when creating the result file), but that seemed out of scope.

After that, I could wire up the `ProcessorMap` object and we have a much stronger map. There are some fun things like `Filter` subclasses of `Object` which "pass through" their shape (though they set top level over child) that can be handled differently. I ported over the UI I demoed. @sal-uva feel free to trash it or use it as desired; I mostly wanted it again to verify the API returned sensible results.