### PR TITLE
CI to export module catalog to 4cat-site

### DIFF
--- a/.github/workflows/docker_new_release.yml
+++ b/.github/workflows/docker_new_release.yml
@@ -1,4 +1,17 @@
-# This will publish an image to Docker Hub on a new release
+# On a new release this publishes the Docker image, and then publishes the module
+# catalogue -- the public list of every data source and processor in the release --
+# as a static site, by opening a pull request against digitalmethodsinitiative/4cat-site.
+#
+# The two jobs are deliberately independent: the catalogue runs after the image and
+# cannot hold it up or undo it. See docs/module-catalog-export-contract.md for what
+# the catalogue bundle has to contain and why.
+#
+# Required secrets (Settings -> Secrets and variables -> Actions):
+#   DOCKER_DALE_LOGIN / DOCKER_DALE_PASSWORD - Docker Hub credentials
+#   CATALOGUE_SITE_APP_ID                    - numeric App ID of the GitHub App installed on
+#                                              digitalmethodsinitiative/4cat-site with permissions
+#                                              contents:write + pull-requests:write (and nothing else)
+#   CATALOGUE_SITE_APP_PRIVATE_KEY           - full PEM private key for that App (with BEGIN/END lines)
 
 name: Publish new release to Docker Hub
 
@@ -6,11 +19,32 @@ name: Publish new release to Docker Hub
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Publish the catalogue as this release tag (e.g. v1.56). Leave empty to build a development snapshot of this commit, which must not replace the public catalogue.'
+        type: string
+        default: ''
+      open_pull_request:
+        description: 'Open a pull request against 4cat-site. Off by default for manual runs; the bundle is always attached to the run as an artifact.'
+        type: boolean
+        default: false
+
+# Least privilege: this workflow's own token only reads this repository. Writing to
+# 4cat-site is done with a separate, narrowly scoped App token minted below.
+permissions:
+  contents: read
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
+    # Only a real release publishes an image; a manual run is for the catalogue.
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    outputs:
+      # The tag the image was actually pushed under, so the catalogue job runs the
+      # exporter inside that exact image rather than guessing its name.
+      version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -52,3 +86,304 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: digitalmethodsinitiative/4cat:stable
+
+  module_catalogue:
+    name: Publish the module catalogue
+    needs: push_to_registry
+    # Runs after the image on a release, and on its own for a manual run (where
+    # push_to_registry is skipped, not failed). Never runs if the image build failed:
+    # there would be nothing to export from.
+    if: always() && needs.push_to_registry.result != 'failure'
+    runs-on: ubuntu-latest
+    # Raised from the workflow's read-only default for one step: attaching the
+    # catalogue archive to the release. Writing to 4cat-site is not covered by this
+    # and uses the separate App token minted below.
+    permissions:
+      contents: write
+    # The catalogue is an extra. A broken export must leave the previously published
+    # catalogue in place and report itself, not turn a good release red -- so the job
+    # is allowed to fail without failing the run, and says so in the run summary.
+    continue-on-error: true
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          # Full history and tags: the provenance recorded in the published bundle is
+          # worked out here, where git can see the tags, rather than inside the
+          # container, which was built from a shallow checkout that has none.
+          fetch-depth: 0
+
+      - name: Work out what is being published
+        id: provenance
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          IMAGE_VERSION: ${{ needs.push_to_registry.outputs.version }}
+          COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # 4CAT is started the way the rest of this repository's CI starts it, so the
+          # export runs against a properly set up instance.
+          #
+          # A release starts the image that was just published, so the catalogue comes
+          # from exactly the code that was released. A manual run has no such image
+          # and builds one from the checkout instead.
+          if [ "$EVENT_NAME" = "release" ]; then
+            echo "compose_file=docker-compose.yml" >> "$GITHUB_OUTPUT"
+            echo "docker_tag=$IMAGE_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "compose_file=docker-compose_build.yml" >> "$GITHUB_OUTPUT"
+            echo "docker_tag=stable" >> "$GITHUB_OUTPUT"
+          fi
+
+          # An empty tag means "not a release", and the exporter will publish this as
+          # a development snapshot that says so on the page.
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "release_arg=--release-tag $RELEASE_TAG" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_arg=" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Recorded in the bundle so a published catalogue can always be traced back
+          # to the commit it came from, and re-exported to the same bytes.
+          echo "described=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+          echo "committed_at=$(git show -s --format=%cI "$COMMIT")" >> "$GITHUB_OUTPUT"
+
+      - name: Start 4CAT
+        env:
+          # Compose reads this from the environment in preference to .env, so the
+          # release starts the image that was just published rather than the default.
+          DOCKER_TAG: ${{ steps.provenance.outputs.docker_tag }}
+          COMPOSE_FILE: ${{ steps.provenance.outputs.compose_file }}
+        # Only the backend, which brings up the database and memcached it depends on.
+        # The frontend plays no part in an export.
+        run: docker compose -f "$COMPOSE_FILE" up -d backend
+
+      - name: Wait for 4CAT to finish setting itself up
+        env:
+          COMPOSE_FILE: ${{ steps.provenance.outputs.compose_file }}
+        run: |
+          set -euo pipefail
+          # The entrypoint seeds the database, runs the migrations, and only then
+          # writes config.ini. Waiting for that file waits for the part the export
+          # actually depends on, rather than guessing at a length of time.
+          for _ in $(seq 1 60); do
+            if docker exec 4cat_backend test -f config/config.ini; then
+              echo "4CAT is set up."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "4CAT did not finish starting up within five minutes."
+          docker compose -f "$COMPOSE_FILE" logs backend
+          exit 1
+
+      - name: Export the catalogue
+        env:
+          RELEASE_ARG: ${{ steps.provenance.outputs.release_arg }}
+          COMMIT: ${{ github.sha }}
+          DESCRIBED: ${{ steps.provenance.outputs.described }}
+          COMMITTED_AT: ${{ steps.provenance.outputs.committed_at }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # The exporter validates its own output and exits non-zero rather than
+          # writing an incomplete catalogue, so a failure here means nothing was
+          # published. Values are passed through the environment rather than
+          # interpolated, and $RELEASE_ARG is left unquoted on purpose so that it
+          # word-splits into two arguments, or into none when it is empty.
+          docker exec \
+            -e COMMIT -e DESCRIBED -e COMMITTED_AT -e RELEASE_ARG \
+            4cat_backend sh -c '
+              exec python3 helper-scripts/export_module_catalogue.py \
+                --output /usr/src/app/dist/catalog \
+                --commit "$COMMIT" \
+                --git-describe "$DESCRIBED" \
+                --generated-at "$COMMITTED_AT" \
+                $RELEASE_ARG
+            '
+          # Copied out rather than written through a mounted directory, so the files
+          # arrive owned by the user this job runs as and the later steps can commit
+          # them without having to take ownership first.
+          docker cp 4cat_backend:/usr/src/app/dist/catalog ./dist/catalog
+
+      - name: Check the renderer is valid JavaScript
+        # The one check the exporter cannot run itself: node is not in the 4CAT
+        # image, but it is on the runner. The renderer is copied byte-for-byte from
+        # webtool/static/js/module-catalog.js, so a failure here means that file is
+        # broken -- in the application as much as in the published catalogue.
+        run: node --check dist/catalog/assets/catalogue.js
+
+      - name: Summarise what was built
+        id: bundle
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import hashlib, json, pathlib
+
+          bundle = pathlib.Path("dist/catalog")
+          manifest = json.loads(bundle.joinpath("manifest.json").read_text(encoding="utf-8"))
+          data = bundle.joinpath(manifest["data_file"]).read_bytes()
+          catalogue = json.loads(data)["catalogue"]
+
+          source = manifest["source"]
+          print("kind=%s" % source["kind"])
+          print("version=%s" % source["fourcat_version"])
+          print("release_tag=%s" % (source["release_tag"] or ""))
+          print("commit=%s" % source["git_commit"])
+          print("modules=%i" % len(catalogue))
+          print("datasources=%i" % sum(1 for entry in catalogue if entry["is_datasource"]))
+          print("sha256=%s" % hashlib.sha256(data).hexdigest())
+          PY
+
+      - name: Upload the bundle as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 4cat-module-catalogue-${{ steps.bundle.outputs.version }}
+          path: dist/catalog
+          if-no-files-found: error
+
+      - name: Attach the bundle to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          tar -czf "4cat-module-catalogue-${TAG}.tar.gz" -C dist catalog
+          gh release upload "$TAG" "4cat-module-catalogue-${TAG}.tar.gz" --clobber --repo "$GITHUB_REPOSITORY"
+
+      # --- publish to the public site -------------------------------------------
+      # Only a real release replaces the public catalogue. A development snapshot is
+      # built and kept as an artifact so it can be looked at, but never published:
+      # the public page must describe a release, not somebody's work in progress.
+
+      - name: Mint 4cat-site App token
+        id: app_token
+        if: steps.provenance.outputs.is_release == 'true' && (github.event_name == 'release' || inputs.open_pull_request)
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CATALOGUE_SITE_APP_ID }}
+          private-key: ${{ secrets.CATALOGUE_SITE_APP_PRIVATE_KEY }}
+          owner: digitalmethodsinitiative
+          repositories: 4cat-site
+
+      - name: Check out 4cat-site
+        if: steps.app_token.outcome == 'success'
+        uses: actions/checkout@v4
+        with:
+          repository: digitalmethodsinitiative/4cat-site
+          path: site-checkout
+          token: ${{ steps.app_token.outputs.token }}
+
+      - name: Replace the published catalogue
+        if: steps.app_token.outcome == 'success'
+        run: |
+          set -euo pipefail
+          # Replace the directory wholesale rather than copying files over an older
+          # export: that way files a newer export no longer produces are removed
+          # instead of being left behind to be served alongside the new ones.
+          rm -rf site-checkout/public/catalog
+          mkdir -p site-checkout/public
+          cp -r dist/catalog site-checkout/public/catalog
+
+      - name: Write the pull request body
+        if: steps.app_token.outcome == 'success'
+        env:
+          KIND: ${{ steps.bundle.outputs.kind }}
+          VERSION: ${{ steps.bundle.outputs.version }}
+          RELEASE_TAG: ${{ steps.bundle.outputs.release_tag }}
+          COMMIT: ${{ steps.bundle.outputs.commit }}
+          MODULES: ${{ steps.bundle.outputs.modules }}
+          DATASOURCES: ${{ steps.bundle.outputs.datasources }}
+          SHA256: ${{ steps.bundle.outputs.sha256 }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # A heredoc with the values passed through the environment, so nothing from
+          # a tag or version name is interpolated into the file by the shell.
+          cat > pr_body.md <<'EOF'
+          Generated from a 4CAT release by the 4CAT release workflow. It replaces the
+          whole of `public/catalog/` with a freshly exported bundle.
+
+          EOF
+          {
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| 4CAT version | \`${VERSION}\` |"
+            echo "| Release tag | \`${RELEASE_TAG}\` |"
+            echo "| Commit | \`${COMMIT}\` |"
+            echo "| Modules | ${MODULES}, of which ${DATASOURCES} data sources |"
+            echo "| Data file sha256 | \`${SHA256}\` |"
+            echo ""
+            echo "- Release: ${RELEASE_URL}"
+            echo "- Build: ${RUN_URL}"
+            echo ""
+            echo "Extensions are deliberately excluded: this describes an official 4CAT"
+            echo "release, not the modules installed on any particular server."
+            echo ""
+            echo "Worth checking before merging: that the version and commit above are the"
+            echo "release you expect, that the module count has not changed unexpectedly,"
+            echo "and that the rendered page still looks right."
+            # A manual run builds from whatever branch it was started on and labels the
+            # result with whatever tag was typed in. That is useful for rehearsing this
+            # process, and would be a lie to publish, so it says so plainly.
+            if [ "$EVENT_NAME" != "release" ]; then
+              echo ""
+              echo "> **Started by hand, not by a release.** This was built from"
+              echo "> \`${REF_NAME}\` and labelled \`${RELEASE_TAG}\`, which is not"
+              echo "> necessarily the code that tag points at. Check the commit above"
+              echo "> before merging, or close this if it was only a rehearsal."
+            fi
+          } >> pr_body.md
+
+      - name: Open or update the 4cat-site pull request
+        if: steps.app_token.outcome == 'success'
+        # Third-party action that operates with a write token to 4cat-site -- pinned
+        # to a full commit SHA (the v6 release) rather than the mutable `@v6` tag, so
+        # a tag move cannot silently change what runs here.
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        with:
+          path: site-checkout
+          token: ${{ steps.app_token.outputs.token }}
+          branch: auto/module-catalogue-${{ steps.bundle.outputs.release_tag }}
+          title: "Update module catalogue to 4CAT ${{ steps.bundle.outputs.release_tag }}"
+          commit-message: "chore: update module catalogue to 4CAT ${{ steps.bundle.outputs.release_tag }}"
+          body-path: pr_body.md
+
+      - name: Show 4CAT's logs if something went wrong
+        if: failure()
+        env:
+          COMPOSE_FILE: ${{ steps.provenance.outputs.compose_file }}
+        run: |
+          echo "::group::4CAT backend container"
+          docker compose -f "$COMPOSE_FILE" logs backend || true
+          echo "::endgroup::"
+          echo "::group::4CAT backend log file"
+          docker exec 4cat_backend sh -c 'cat logs/backend_4cat.log 2>/dev/null || cat data/logs/backend_4cat.log 2>/dev/null' || true
+          echo "::endgroup::"
+
+      - name: Say what happened
+        if: always()
+        env:
+          KIND: ${{ steps.bundle.outputs.kind }}
+          MODULES: ${{ steps.bundle.outputs.modules }}
+        run: |
+          set -eu
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "Exported ${MODULES} modules as a ${KIND}." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### The module catalogue was not published"
+              echo ""
+              echo "The release itself is unaffected -- the Docker image was published by a"
+              echo "separate job, and the previously published catalogue is still in place."
+              echo "The export refuses to publish an incomplete or drifted bundle, so this"
+              echo "means something needs fixing before the catalogue can be updated."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/module-catalog-export-contract.md
+++ b/docs/module-catalog-export-contract.md
@@ -1,0 +1,274 @@
+# Module Catalogue: Static Export Contract
+
+## Purpose
+
+4CAT renders its module catalogue — every data source and processor in a
+release, with compatibility information and provenance — using one shared
+renderer in two places:
+
+- inside the running 4CAT application, backed by its live API; and
+- as a self-contained static bundle published on the public 4CAT website
+  ([`4cat-site`](https://github.com/digitalmethodsinitiative/4cat-site)) at
+  `https://4cat.nl/catalog/`.
+
+This document is the standing contract for the **static export**: what the
+exporter must produce so that `4cat-site` can publish the catalogue with no live
+4CAT instance, no catalogue API, and no server-side templating.
+
+4CAT owns the exported content and the renderer. `4cat-site` integrates and
+deploys the bundle; see its `docs/catalogue-site-integration.md` for the
+consuming side of this contract.
+
+## Ownership boundary
+
+| Concern | Owner |
+| --- | --- |
+| Module metadata, compatibility mapping, renderer, generated CSS/JS/data | 4CAT export (this repository) |
+| The exported `catalog/` bundle | 4CAT export, reviewed in `4cat-site` |
+| `/catalog/` public route, homepage link, deployment, caching | `4cat-site` |
+| Extensions library | `4cat-site`; excluded from this export |
+
+## Where this lives in 4CAT
+
+| File | Role |
+| --- | --- |
+| [`helper-scripts/export_module_catalogue.py`](../helper-scripts/export_module_catalogue.py) | The exporter. Builds the bundle, writes the manifest, and runs the validation below. |
+| [`webtool/static/module-catalog/index.html`](../webtool/static/module-catalog/index.html) | The static page shell, and the only place `window.MODULE_CATALOG_SOURCE` is defined. Declares which `format_version` and `schema_version` it can read. |
+| [`webtool/templates/components/module-catalog-body.html`](../webtool/templates/components/module-catalog-body.html) | The catalogue markup, shared verbatim by the static page and the live one. Must stay plain HTML. |
+| [`webtool/templates/module-catalog.html`](../webtool/templates/module-catalog.html) | The live 4CAT page. Includes the shared markup and supplies what only Flask can. |
+| [`webtool/static/js/module-catalog.js`](../webtool/static/js/module-catalog.js) | The shared renderer, copied into the bundle unchanged as `assets/catalogue.js`. Falls back to the live API adapter when no `MODULE_CATALOG_SOURCE` is defined. |
+| [`webtool/static/css/module-catalog.css`](../webtool/static/css/module-catalog.css) | Catalogue styling. Published together with `fourcat-new.css` and everything it imports, so the public page tracks the application's design. |
+| [`common/lib/processor_map.py`](../common/lib/processor_map.py) | Computes the catalogue and detail records. The exporter serialises exactly what the live API returns. |
+| [`webtool/views/api_processor_map.py`](../webtool/views/api_processor_map.py) | The live API the same renderer uses inside the application. |
+| [`tests/test_module_catalogue_export.py`](../tests/test_module_catalogue_export.py) | Enforces this contract, including that each refusal below actually happens. |
+
+Two properties keep the public catalogue and the one inside 4CAT from drifting
+apart, and the exporter refuses to publish if either lapses:
+
+- Both pages read their markup from one shared file, so neither can quietly grow
+  its own copy.
+- The published stylesheets are discovered by following `fourcat-new.css`'s own
+  imports rather than from a list kept here, so adding or removing part of 4CAT's
+  styling needs no change to the exporter.
+
+## Running the export
+
+```bash
+python helper-scripts/export_module_catalogue.py --output dist/catalogue
+```
+
+4CAT's dependencies must be importable, so in a Docker install run it inside the
+backend container. Serve the result with any static file server to review it —
+opening `index.html` from disk will not work, because browsers block `fetch()` on
+`file://` URLs.
+
+For a release, name the tag explicitly:
+
+```bash
+python helper-scripts/export_module_catalogue.py --output dist/catalogue --release-tag v1.56
+```
+
+Without `--release-tag`, a release is claimed only when the commit carries a tag
+exactly. **A CI checkout is usually shallow and has no tags**, so a genuine release
+left to work it out from git would publish itself as a development snapshot. Release
+automation should always pass the tag.
+
+## Bundle shape
+
+The exporter produces one self-contained directory that is copied verbatim into
+`4cat-site` at `public/catalog/`:
+
+```text
+catalog/
+    index.html             # static page; defines the static data adapter
+    manifest.json          # bundle entry point (read first)
+    data/
+        catalogue-v1.json  # module summaries + details
+    assets/
+        catalogue.js       # shared renderer (the same file the live app uses)
+        css/
+        fontawesome/
+        img/
+```
+
+Every reference inside the bundle resolves to another file inside the bundle. The
+bundle must work from a plain static web server with no application behind it, and
+must not depend on being served from any particular path.
+
+## `manifest.json` — the bundle entry point
+
+`manifest.json` is the single file the public page reads first. It names the data
+file to load and describes the source revision the catalogue was built from.
+
+Current contract: **`format_version` 2.**
+
+Release build:
+
+```json
+{
+  "format_version": 2,
+  "data_schema_version": 1,
+  "source": {
+    "kind": "release",
+    "fourcat_version": "1.56",
+    "release_tag": "v1.56",
+    "git_describe": "v1.56",
+    "git_commit": "a6e11f52ea3ca3a4a030e54f86ec555f33dd9099",
+    "generated_at": "2026-07-28T10:42:50+02:00"
+  },
+  "data_file": "data/catalogue-v1.json"
+}
+```
+
+Development snapshot (any commit that is not exactly on a release tag):
+
+```json
+{
+  "format_version": 2,
+  "data_schema_version": 1,
+  "source": {
+    "kind": "development_snapshot",
+    "fourcat_version": "1.56",
+    "release_tag": null,
+    "git_describe": "v1.55-146-g8f0c31da1",
+    "git_commit": "8f0c31da1c9b520c8a8705e5975fca253fe95eb2",
+    "generated_at": "2026-07-28T16:31:01+02:00"
+  },
+  "data_file": "data/catalogue-v1.json"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `format_version` | Version of the static bundle/manifest contract. Increment for breaking manifest changes. Currently `2`. |
+| `data_schema_version` | Expected `schema_version` in the data JSON. Currently `1`. |
+| `source.kind` | `release` or `development_snapshot`. |
+| `source.fourcat_version` | 4CAT version reported by the build. |
+| `source.release_tag` | Exact Git release tag, or `null` when the commit is not exactly tagged. |
+| `source.git_describe` | Human-readable `git describe` output; may describe a commit after a tag. |
+| `source.git_commit` | Full immutable source revision. |
+| `source.generated_at` | ISO 8601 timestamp with timezone. |
+| `data_file` | Relative path from `catalog/` to the data JSON. |
+
+## Data file
+
+The data JSON keeps its own `schema_version` (currently `1`), which describes the
+module-data format. `format_version` describes the outer bundle; the two solve
+different compatibility problems and must not be conflated.
+
+The data file contains:
+
+- `catalogue`: an array of module **summaries** used to draw the browse grid.
+- `modules`: an object of module **detail** records keyed by module `type`.
+
+Invariants:
+
+- Every module `type` is unique and non-empty.
+- Every `catalogue` summary has exactly one matching `modules` detail record, and
+  there are no detail records without a summary.
+
+## Provenance rules
+
+Determine at export time whether the source commit is exactly tagged.
+
+- Exact release tag → `source.kind = "release"`, `release_tag` = that tag.
+- Any commit after a tag → `source.kind = "development_snapshot"`,
+  `release_tag = null`.
+- Always include the full commit hash and `git describe` output.
+- **Never infer a release tag from `git describe` alone.** A value like
+  `v1.55-146-g8f0c31da1` means 146 commits after `v1.55`; it is not a release.
+
+The published page uses these fields to say either "Catalogue for 4CAT v1.56" or
+"Development snapshot of 4CAT 1.56 — not a released version". Truthful provenance
+here is what keeps the public page honest.
+
+## Fully static bundle
+
+- No Flask/Jinja template syntax and no calls to a live 4CAT API in the exported
+  files. The export must refuse to publish if it finds unresolved template
+  delimiters or other server-side placeholders.
+- Every path to HTML, JavaScript, CSS, images, Font Awesome assets, and data is
+  relative to the file that names it, never rooted at `/`, and always resolves to
+  something inside the bundle. That is what lets `catalog/` be served from any
+  location without rewriting it.
+- The static page defines `window.MODULE_CATALOG_SOURCE` as the data adapter for
+  the shared renderer: it reads the exported JSON and addresses modules with
+  `?module=<type>`. The live 4CAT application keeps its own API adapter; the
+  renderer is otherwise identical in both.
+- Extensions are excluded until the extension-library policy and data model are
+  defined separately.
+- The page currently loads its typefaces from Google Fonts (one external
+  request). This is an accepted design choice; a future exporter may bundle the
+  font files locally if privacy, offline use, or typography consistency justifies
+  it.
+
+## Export validation
+
+The exporter must fail rather than publish a partially valid bundle. Before
+finalising the bundle, confirm:
+
+1. `manifest.json` and the file named by `data_file` parse as JSON.
+2. `format_version` and the data `schema_version` are the versions the generated
+   renderer supports.
+3. Every `catalogue` summary has exactly one matching `modules` detail record,
+   with no extra detail records.
+4. Every module has a unique, non-empty `type`.
+5. `data_file` exists below the exported `catalog/` directory.
+6. Every local file referenced by the generated HTML and CSS exists.
+7. The exported HTML contains no unresolved template delimiters or other
+   server-side placeholders.
+8. The generated renderer is present and not empty, and passes a JavaScript syntax
+   check where one can be run.
+
+Check 2 is a cross-check between the page and the exporter: the page states the
+versions it can read, and the exporter compares its own output against that
+statement. Neither side can move without the other noticing.
+
+Check 8 is conditional. The syntax check runs `node --check`, and **node is not part
+of the 4CAT Docker image**, so in a normal export it is reported as not run rather
+than silently assumed. Release automation should run the same check as a separate
+step on a runner that has node. The renderer is copied byte-for-byte from
+`webtool/static/js/module-catalog.js`, so a failure here means 4CAT's own file is
+broken.
+
+Report the source kind, release tag (when present), commit, module count, output
+directory, and whether the renderer was syntax-checked in the build log.
+
+`4cat-site` re-runs the equivalent static checks on every pull request that
+touches the bundle (`scripts/validate_catalog.py` there), but the exporter is the
+first line of defence and should not emit a bundle those checks would reject.
+
+## Release and handoff flow
+
+```mermaid
+flowchart LR
+    tag[Tagged 4CAT release] --> export[Generate and validate catalog bundle]
+    export --> pr[Open PR in 4cat-site replacing public/catalog/]
+    pr --> ci[4cat-site CI validates bundle]
+    ci --> review[Review provenance and visible changes]
+    review --> deploy[Merge and deploy 4cat.nl]
+```
+
+- Use **tagged releases** as the source for the public production catalogue.
+- Replace the **complete** `public/catalog/` directory in one pull request; do
+  not copy individual data or asset files into an existing export. This keeps the
+  page, renderer, styles, and data in a known-compatible set. In practice, build
+  the directory fresh so files a newer export no longer produces are removed
+  rather than left behind.
+- Do not auto-merge initially. Review is a useful final check on release
+  provenance, module count, visible descriptions, and unintended changes.
+- Development snapshots may be exported for local testing or a staging site, but
+  should not silently replace the public release catalogue.
+
+## Changing the contract
+
+`format_version` and `data_schema_version` are the coordination points between
+this repository and `4cat-site`:
+
+- Bump `data_schema_version` when the module-data shape changes incompatibly.
+- Bump `format_version` when the manifest/bundle contract changes incompatibly.
+- Ship a renderer that understands the new version, and coordinate the change
+  with `4cat-site` — whose loader checks both versions and will reject a bundle it
+  does not recognise — before publishing.
+
+See `4cat-site`'s `docs/catalogue-site-integration.md` for the consuming side.

--- a/docs/module-catalog-export-contract.md
+++ b/docs/module-catalog-export-contract.md
@@ -62,6 +62,16 @@ backend container. Serve the result with any static file server to review it —
 opening `index.html` from disk will not work, because browsers block `fetch()` on
 `file://` URLs.
 
+The export also needs a `config/config.ini`, like any other 4CAT command: loading
+the data sources imports `common/lib/helpers.py`, which reads the configuration as
+it is imported. Starting 4CAT normally writes that file — under Docker the
+entrypoint generates it from `.env` — so a running instance already has one, which
+is why the release workflow starts 4CAT rather than running the exporter against a
+bare image. A container started without that setup has no `config.ini` at all, since
+the file is never committed; copying `config/config.ini-example` over it is enough
+to make the import work. Nothing in it reaches the catalogue either way, because the
+exporter supplies its own paths.
+
 For a release, name the tag explicitly:
 
 ```bash
@@ -72,6 +82,13 @@ Without `--release-tag`, a release is claimed only when the commit carries a tag
 exactly. **A CI checkout is usually shallow and has no tags**, so a genuine release
 left to work it out from git would publish itself as a development snapshot. Release
 automation should always pass the tag.
+
+The same applies to the rest of the provenance. A release is exported inside a
+container built from that shallow checkout, so `--commit`, `--generated-at` and
+`--git-describe` should be worked out on the machine that has the full history and
+passed in, rather than left for the container's git to guess. See the
+`module_catalogue` job in
+[`.github/workflows/docker_new_release.yml`](../.github/workflows/docker_new_release.yml).
 
 ## Bundle shape
 

--- a/helper-scripts/export_module_catalogue.py
+++ b/helper-scripts/export_module_catalogue.py
@@ -40,10 +40,17 @@ sys.path.insert(0, str(PATH_ROOT))
 from common.lib.module_loader import ModuleCollector  # noqa: E402
 from common.lib.processor_map import ProcessorMap  # noqa: E402
 
-# Raise this only when the published data changes in a way an older page cannot
-# read; the page refuses a file it does not understand rather than showing gaps.
+# Two separate promises, raised separately.
+#
+# FORMAT_VERSION covers the shape of the bundle: that there is a manifest, that it
+# names the data file, and what else it carries. SCHEMA_VERSION covers the module
+# data inside that file. A page written for one release can then tell "I do not
+# understand this bundle at all" apart from "I found the data but not in a shape I
+# can read", and refuse either rather than drawing half a catalogue.
+FORMAT_VERSION = 2
 SCHEMA_VERSION = 1
 DATA_FILE = "data/catalogue-v1.json"
+MANIFEST_FILE = "manifest.json"
 
 PATH_STATIC = PATH_ROOT.joinpath("webtool", "static")
 
@@ -74,6 +81,26 @@ ASSETS = (
 # Another file a stylesheet pulls in: `url(...)` covers both plain references and
 # `@import url(...)`; the second half catches an `@import` written without `url`.
 CSS_REFERENCE = re.compile(r"""url\(\s*['"]?([^'")]+)['"]?\s*\)|@import\s+['"]([^'"]+)['"]""")
+
+# A file the finished page or a stylesheet loads as part of itself: a <link>,
+# anything with a src, or a url() in CSS. Deliberately not <a href>, which is
+# somewhere a visitor may choose to go rather than something the page fetches --
+# the page is meant to link out to the 4CAT site and to the release it describes.
+PAGE_REFERENCE = re.compile(
+    r"""<link\b[^>]*\bhref\s*=\s*["']([^"']+)["']"""
+    r"""|\bsrc\s*=\s*["']([^"']+)["']"""
+    r"""|url\(\s*["']?([^"')]+?)["']?\s*\)""",
+    re.IGNORECASE)
+
+
+def page_references(text):
+    """Every file the given page or stylesheet expects to find beside it."""
+    found = set()
+    for match in PAGE_REFERENCE.finditer(text):
+        reference = (match.group(1) or match.group(2) or match.group(3) or "").strip()
+        if reference and not reference.startswith(("http://", "https://", "//", "data:", "#")):
+            found.add(reference.split("?")[0].split("#")[0])
+    return found
 
 
 class ExportConfig:
@@ -127,6 +154,44 @@ def git(*arguments, default=""):
     except (OSError, subprocess.SubprocessError):
         return default
     return result.stdout.strip() if result.returncode == 0 else default
+
+
+def describe_source(version=None, release_tag=None, commit=None, generated_at=None):
+    """
+    Work out what exactly is being published, and say so plainly.
+
+    The distinction that matters to a reader is whether this is a 4CAT release or
+    somebody's work in progress. Git's `describe` cannot answer that on its own:
+    "v1.55-145-ga6e11f52e" means 145 commits *after* v1.55, so treating it as a
+    release tag would put a version on the public page that was never released.
+
+    So a release is only claimed when the commit carries that tag exactly, or when
+    whoever is running the export names the tag themselves. Everything else is a
+    development snapshot, and says so. `git_describe` is still recorded, because it
+    is the most human-readable summary of where a commit sits.
+
+    Note for automation: a shallow checkout has no tags, so `describe` finds nothing
+    and even a real release would look like a snapshot. Release builds should pass
+    --release-tag rather than relying on what git can work out.
+    """
+    tag = release_tag if release_tag is not None else git("describe", "--exact-match", "--tags", "HEAD")
+    tag = tag.strip() or None
+
+    # only the first line of VERSION is the version; the rest explains the file
+    version_file = PATH_ROOT.joinpath("VERSION")
+    if not version and version_file.exists():
+        version = version_file.read_text(encoding="utf-8").splitlines()[0].strip()
+
+    return {
+        "kind": "release" if tag else "development_snapshot",
+        "fourcat_version": version or "unknown",
+        "release_tag": tag,
+        "git_describe": git("describe", "--tags", "--always", default="unknown"),
+        "git_commit": commit or git("rev-parse", "HEAD", default="unknown"),
+        # the commit's own date, so exporting a release again reproduces it exactly
+        "generated_at": generated_at or git("show", "-s", "--format=%cI", "HEAD")
+            or datetime.now(timezone.utc).isoformat(),
+    }
 
 
 def build_map(scratch):
@@ -188,9 +253,10 @@ def prepare_output(output):
     to stop than to empty out a directory that turns out to be something else.
     """
     if output.exists() and any(output.iterdir()):
-        if not output.joinpath("manifest.json").exists():
+        if not output.joinpath(MANIFEST_FILE).exists():
             raise RuntimeError("%s is not empty and does not look like an earlier catalogue "
-                               "export (it has no manifest.json), so it was left untouched" % output)
+                               "export (it has no %s), so it was left untouched"
+                               % (output, MANIFEST_FILE))
         shutil.rmtree(output)
     output.mkdir(parents=True, exist_ok=True)
 
@@ -287,6 +353,119 @@ def write_page(output):
     output.joinpath("index.html").write_text(shell.replace(BODY_MARKER, body), encoding="utf-8")
 
 
+def check_bundle(output):
+    """
+    Read the finished bundle back and check it is fit to publish.
+
+    Everything up to here checked what went in; this checks what came out, by
+    reading the files the way a visitor's browser will. Every problem found is
+    collected rather than raised one at a time, so a broken export can be fixed in
+    one go instead of one error per attempt.
+    """
+    problems = []
+
+    def read_json(name):
+        try:
+            return json.loads(output.joinpath(name).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            problems.append("%s cannot be read as JSON: %s" % (name, e))
+            return None
+
+    manifest = read_json(MANIFEST_FILE)
+    page = output.joinpath("index.html").read_text(encoding="utf-8")
+
+    # the manifest names the data file, so follow it rather than assuming the name
+    data = None
+    if manifest:
+        named = str(manifest.get("data_file", ""))
+        target = output.joinpath(named).resolve()
+        if not named or output.resolve() not in target.parents:
+            problems.append("the manifest's data_file (%r) is not inside the bundle" % named)
+        elif not target.exists():
+            problems.append("the manifest names %s, which is not in the bundle" % named)
+        else:
+            data = read_json(named)
+
+    # the page has to understand both the bundle and the data it is given
+    for label, declared, expected in (
+            ("manifest", re.search(r"SUPPORTED_MANIFEST\s*=\s*(\d+)", page), FORMAT_VERSION),
+            ("data", re.search(r"SUPPORTED_DATA\s*=\s*(\d+)", page), SCHEMA_VERSION)):
+        if not declared:
+            problems.append("the page does not say which %s version it can read" % label)
+        elif int(declared.group(1)) != expected:
+            problems.append("the page reads %s version %s, but this export writes version %i"
+                            % (label, declared.group(1), expected))
+
+    if manifest:
+        if manifest.get("format_version") != FORMAT_VERSION:
+            problems.append("the manifest says format_version %r, expected %i"
+                            % (manifest.get("format_version"), FORMAT_VERSION))
+        if manifest.get("data_schema_version") != SCHEMA_VERSION:
+            problems.append("the manifest says data_schema_version %r, expected %i"
+                            % (manifest.get("data_schema_version"), SCHEMA_VERSION))
+        if data and data.get("schema_version") != manifest.get("data_schema_version"):
+            problems.append("the data file and the manifest disagree about the data version")
+        if data and data.get("source") != manifest.get("source"):
+            problems.append("the data file and the manifest disagree about where this came from")
+
+    # every module listed to browse has exactly one detailed record, and vice versa
+    if data:
+        listed = [entry.get("type") for entry in data.get("catalogue", [])]
+        if not all(listed):
+            problems.append("a module in the catalogue has no type")
+        if len(set(listed)) != len(listed):
+            problems.append("the catalogue lists the same module more than once")
+        detailed = set(data.get("modules", {}))
+        for missing in sorted(set(listed) - detailed):
+            problems.append("%s is listed but has no details" % missing)
+        for extra in sorted(detailed - set(listed)):
+            problems.append("%s has details but is not listed" % extra)
+
+    # nothing left for a template engine to fill in, since nothing will
+    for delimiter in ("{{", "{%", "{#"):
+        if delimiter in page:
+            problems.append("index.html still contains %s, which nothing will fill in" % delimiter)
+
+    # everything the page and its styling load has to be here, and stay here
+    for source_file in [output.joinpath("index.html"), *sorted(output.rglob("*.css"))]:
+        for reference in page_references(source_file.read_text(encoding="utf-8")):
+            target = source_file.parent.joinpath(reference).resolve()
+            where = source_file.relative_to(output)
+            if output.resolve() not in target.parents:
+                problems.append("%s reaches outside the bundle for %s" % (where, reference))
+            elif not target.exists():
+                problems.append("%s needs %s, which is not in the bundle" % (where, reference))
+
+    if problems:
+        raise RuntimeError("the export came out wrong, so nothing was published:\n  %s"
+                           % "\n  ".join(problems))
+
+    return check_javascript(output.joinpath("assets", "catalogue.js"))
+
+
+def check_javascript(script):
+    """
+    Check the renderer is valid JavaScript, where there is something to check it
+    with. Returns what was done, to be reported rather than quietly assumed.
+
+    Node is not part of the 4CAT image, so this usually cannot run here; a release
+    pipeline that has it should run this same check.
+    """
+    if not script.exists():
+        raise RuntimeError("the renderer is missing from the bundle")
+    if not script.read_text(encoding="utf-8").strip():
+        raise RuntimeError("the renderer in the bundle is empty")
+
+    try:
+        result = subprocess.run(["node", "--check", str(script)],
+                                capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return "renderer not syntax-checked (node is not available here)"
+    if result.returncode != 0:
+        raise RuntimeError("the renderer is not valid JavaScript:\n%s" % result.stderr.strip())
+    return "renderer checked with node"
+
+
 def export(output, source):
     """Write the whole bundle and return what should be reported about it."""
     prepare_output(output)
@@ -303,20 +482,25 @@ def export(output, source):
     write_page(output)
     stylesheets = copy_stylesheets(output)
     copy_assets(output)
-    output.joinpath("manifest.json").write_text(json.dumps({
-        "format_version": SCHEMA_VERSION,
-        "fourcat_version": source["fourcat_version"],
-        "git_tag": source["git_tag"],
-        "git_commit": source["git_commit"],
-        "generated_at": source["generated_at"],
+
+    # The manifest is what the site reads first: it says what kind of bundle this
+    # is, which data file to load, and which release it describes. `source` is the
+    # same object written into the data file, so the two cannot disagree.
+    output.joinpath(MANIFEST_FILE).write_text(json.dumps({
+        "format_version": FORMAT_VERSION,
+        "data_schema_version": SCHEMA_VERSION,
+        "source": source,
         "data_file": DATA_FILE,
     }, indent=2) + "\n", encoding="utf-8")
+
+    javascript = check_bundle(output)
 
     encoded = data.encode("utf-8")
     return {
         "modules": len(snapshot["catalogue"]),
         "datasources": len([e for e in snapshot["catalogue"] if e["is_datasource"]]),
         "stylesheets": stylesheets,
+        "javascript": javascript,
         "bytes": len(encoded),
         "gzipped": len(gzip.compress(encoded)),
         "sha256": hashlib.sha256(encoded).hexdigest(),
@@ -328,32 +512,32 @@ def main():
     parser.add_argument("--output", required=True, type=Path,
                         help="directory to write the catalogue to")
     parser.add_argument("--version", help="the 4CAT version this describes (default: the VERSION file)")
-    parser.add_argument("--tag", help="the release tag this describes (default: asked of git)")
+    parser.add_argument("--release-tag", help="publish this as an official release of the named tag. "
+                                              "Without it, a release is claimed only when the commit "
+                                              "carries a tag exactly; anything else is published as a "
+                                              "development snapshot. Release builds should pass this, "
+                                              "because a shallow checkout has no tags for git to find.")
     parser.add_argument("--commit", help="the commit this describes (default: asked of git)")
     parser.add_argument("--generated-at", help="timestamp to record (default: the commit's own date, "
                                                "so re-exporting a release reproduces it exactly)")
     arguments = parser.parse_args()
 
-    # only the first line of VERSION is the version; the rest of the file explains
-    # what it is for
-    version_file = PATH_ROOT.joinpath("VERSION")
-    source = {
-        "fourcat_version": arguments.version
-            or (version_file.read_text().splitlines()[0].strip() if version_file.exists() else "unknown"),
-        "git_tag": arguments.tag or git("describe", "--tags", "--always", default="unknown"),
-        "git_commit": arguments.commit or git("rev-parse", "HEAD", default="unknown"),
-        "generated_at": arguments.generated_at or git("show", "-s", "--format=%cI", "HEAD")
-            or datetime.now(timezone.utc).isoformat(),
-    }
+    source = describe_source(version=arguments.version, release_tag=arguments.release_tag,
+                             commit=arguments.commit, generated_at=arguments.generated_at)
 
     try:
         result = export(arguments.output, source)
     except RuntimeError as e:
         sys.exit("Nothing was published: %s" % e)
 
-    print("4CAT %s (tag %s, commit %s)" % (source["fourcat_version"], source["git_tag"], source["git_commit"][:8]))
+    if source["kind"] == "release":
+        print("4CAT release %s (version %s)" % (source["release_tag"], source["fourcat_version"]))
+    else:
+        print("Development snapshot of 4CAT %s -- NOT a release (%s)"
+              % (source["fourcat_version"], source["git_describe"]))
+    print("commit %s, dated %s" % (source["git_commit"], source["generated_at"]))
     print("%i modules, of which %i data sources" % (result["modules"], result["datasources"]))
-    print("%i styling files copied from 4CAT" % result["stylesheets"])
+    print("%i styling files copied from 4CAT; %s" % (result["stylesheets"], result["javascript"]))
     print("%s: %.1f kB, %.1f kB compressed, sha256 %s"
           % (DATA_FILE, result["bytes"] / 1000, result["gzipped"] / 1000, result["sha256"]))
     print("written to %s" % arguments.output.resolve())

--- a/helper-scripts/export_module_catalogue.py
+++ b/helper-scripts/export_module_catalogue.py
@@ -156,7 +156,8 @@ def git(*arguments, default=""):
     return result.stdout.strip() if result.returncode == 0 else default
 
 
-def describe_source(version=None, release_tag=None, commit=None, generated_at=None):
+def describe_source(version=None, release_tag=None, commit=None, generated_at=None,
+                    git_describe=None):
     """
     Work out what exactly is being published, and say so plainly.
 
@@ -172,7 +173,8 @@ def describe_source(version=None, release_tag=None, commit=None, generated_at=No
 
     Note for automation: a shallow checkout has no tags, so `describe` finds nothing
     and even a real release would look like a snapshot. Release builds should pass
-    --release-tag rather than relying on what git can work out.
+    every one of these in rather than relying on what git can work out, because the
+    export usually runs inside a container built from such a checkout.
     """
     tag = release_tag if release_tag is not None else git("describe", "--exact-match", "--tags", "HEAD")
     tag = tag.strip() or None
@@ -186,7 +188,7 @@ def describe_source(version=None, release_tag=None, commit=None, generated_at=No
         "kind": "release" if tag else "development_snapshot",
         "fourcat_version": version or "unknown",
         "release_tag": tag,
-        "git_describe": git("describe", "--tags", "--always", default="unknown"),
+        "git_describe": git_describe or git("describe", "--tags", "--always", default="unknown"),
         "git_commit": commit or git("rev-parse", "HEAD", default="unknown"),
         # the commit's own date, so exporting a release again reproduces it exactly
         "generated_at": generated_at or git("show", "-s", "--format=%cI", "HEAD")
@@ -520,10 +522,14 @@ def main():
     parser.add_argument("--commit", help="the commit this describes (default: asked of git)")
     parser.add_argument("--generated-at", help="timestamp to record (default: the commit's own date, "
                                                "so re-exporting a release reproduces it exactly)")
+    parser.add_argument("--git-describe", help="where this commit sits relative to the last tag, for "
+                                               "the record (default: asked of git, which needs the "
+                                               "tags a shallow checkout does not have)")
     arguments = parser.parse_args()
 
     source = describe_source(version=arguments.version, release_tag=arguments.release_tag,
-                             commit=arguments.commit, generated_at=arguments.generated_at)
+                             commit=arguments.commit, generated_at=arguments.generated_at,
+                             git_describe=arguments.git_describe)
 
     try:
         result = export(arguments.output, source)

--- a/helper-scripts/export_module_catalogue.py
+++ b/helper-scripts/export_module_catalogue.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Export the module catalogue as a static web page.
+
+Writes a self-contained directory -- one HTML page, its stylesheets, JavaScript and
+icons, and a single JSON file holding the data -- describing every data source and
+processor in this checkout. The result can be served by any ordinary web server:
+there is no Python, no database and no 4CAT API behind it.
+
+The data is whatever `ProcessorMap` already computes for the catalogue inside a
+running 4CAT, so the published page and the application page describe the same
+modules and the same relationships. Extensions are deliberately left out, because
+this describes an official 4CAT release rather than one installation's setup.
+
+Run it from the repository root:
+
+    python helper-scripts/export_module_catalogue.py --output dist/catalogue
+
+and then look at the result with, for example:
+
+    python -m http.server --directory dist/catalogue
+"""
+import argparse
+import gzip
+import hashlib
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+PATH_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PATH_ROOT))
+
+from common.lib.module_loader import ModuleCollector  # noqa: E402
+from common.lib.processor_map import ProcessorMap  # noqa: E402
+
+# Raise this only when the published data changes in a way an older page cannot
+# read; the page refuses a file it does not understand rather than showing gaps.
+SCHEMA_VERSION = 1
+DATA_FILE = "data/catalogue-v1.json"
+
+PATH_STATIC = PATH_ROOT.joinpath("webtool", "static")
+
+# The page: a standalone shell, with the catalogue markup that 4CAT's own page uses
+# pasted into it where the marker sits, so the two pages cannot drift apart.
+SHELL = PATH_STATIC.joinpath("module-catalog", "index.html")
+LIVE_PAGE = PATH_ROOT.joinpath("webtool", "templates", "module-catalog.html")
+SHARED_BODY = PATH_ROOT.joinpath("webtool", "templates", "components", "module-catalog-body.html")
+BODY_MARKER = "<!--CATALOGUE-BODY-->"
+
+# The stylesheets to publish. What each is built from is read from the files
+# themselves rather than listed here, so a change to 4CAT's styling needs no change
+# to this script.
+STYLESHEETS = ("fourcat-new.css", "module-catalog.css")
+
+# Files that are neither the page nor a stylesheet, as (file in this repository,
+# place in the bundle). The icons the catalogue draws: ordinary ones in the solid
+# style, data source ones in the brand style.
+ASSETS = (
+    ("webtool/static/js/module-catalog.js", "assets/catalogue.js"),
+    ("webtool/static/fontawesome/css/fontawesome.css", "assets/fontawesome/css/fontawesome.css"),
+    ("webtool/static/fontawesome/css/solid.css", "assets/fontawesome/css/solid.css"),
+    ("webtool/static/fontawesome/css/brands.css", "assets/fontawesome/css/brands.css"),
+    ("webtool/static/fontawesome/webfonts/fa-solid-900.woff2", "assets/fontawesome/webfonts/fa-solid-900.woff2"),
+    ("webtool/static/fontawesome/webfonts/fa-brands-400.woff2", "assets/fontawesome/webfonts/fa-brands-400.woff2"),
+)
+
+# Another file a stylesheet pulls in: `url(...)` covers both plain references and
+# `@import url(...)`; the second half catches an `@import` written without `url`.
+CSS_REFERENCE = re.compile(r"""url\(\s*['"]?([^'")]+)['"]?\s*\)|@import\s+['"]([^'"]+)['"]""")
+
+
+class ExportConfig:
+    """
+    The little bit of configuration the module loader needs, with no database.
+
+    Loading modules only takes a few paths and the list of enabled extensions. The
+    empty extension list is what keeps extensions out of the published catalogue,
+    whether or not any happen to be installed in this checkout.
+    """
+
+    def __init__(self, scratch):
+        self.settings = {
+            "PATH_ROOT": PATH_ROOT,
+            "PATH_DATA": scratch,
+            "PATH_LOGS": scratch.joinpath("logs"),
+            "PATH_EXTENSIONS": PATH_ROOT.joinpath("config", "extensions"),
+            "extensions.enabled": {},
+        }
+
+    def get(self, attribute_name, default=None, is_json=False, user=None, tags=None):
+        return self.settings.get(attribute_name, default)
+
+    def load_user_settings(self, *args, **kwargs):
+        pass
+
+
+class ErrorCollector(logging.Handler):
+    """
+    Remembers the errors reported while the map is built.
+
+    `ProcessorMap` is deliberately forgiving: a module it cannot read is logged and
+    left out so that one broken module cannot take down the whole map. That is right
+    for a running 4CAT and wrong for a published catalogue, where it would quietly
+    drop a module from the public list, so the export reads these back and stops.
+    """
+
+    def __init__(self):
+        super().__init__(level=logging.ERROR)
+        self.errors = []
+
+    def emit(self, record):
+        self.errors.append(record.getMessage())
+
+
+def git(*arguments, default=""):
+    """Ask git something about this checkout; `default` if git cannot answer."""
+    try:
+        result = subprocess.run(["git", "-C", str(PATH_ROOT), *arguments],
+                                capture_output=True, text=True, timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return default
+    return result.stdout.strip() if result.returncode == 0 else default
+
+
+def build_map(scratch):
+    """
+    Load this checkout's core modules and build the map of how they connect.
+
+    Stops rather than returning a short catalogue. There are two separate ways a
+    module can go missing and both are checked, because neither implies the other:
+    it can fail to import at all (the module loader records that), or it can import
+    and then fail while the map reads its declared compatibility and output (the map
+    records that, and its own module list comes up short).
+    """
+    config = ExportConfig(scratch)
+    config.get("PATH_LOGS").mkdir(parents=True, exist_ok=True)
+
+    modules = ModuleCollector(config=config)
+    if modules.missing_modules:
+        raise RuntimeError(
+            "these modules could not be loaded, so the catalogue would be missing "
+            "them: %s. Install what they need and try again." % ", ".join(sorted(modules.missing_modules)))
+
+    collector = ErrorCollector()
+    log = logging.getLogger("module-catalogue-export")
+    log.addHandler(collector)
+    catalogue_map = ProcessorMap(modules, config, logger=log)
+
+    dropped = sorted(set(modules.processors) - set(catalogue_map.processors))
+    if dropped:
+        raise RuntimeError("these modules loaded but could not be read into the map, so the "
+                           "catalogue would be missing them: %s" % ", ".join(dropped))
+    if collector.errors:
+        raise RuntimeError("the map reported problems while it was being built, so the "
+                           "catalogue may be wrong:\n  %s" % "\n  ".join(collector.errors))
+
+    return catalogue_map
+
+
+def build_snapshot(catalogue_map, source):
+    """
+    The published data: a short entry for every module to browse and search, and the
+    full detail for each, shown once a visitor opens one. Both are exactly what the
+    live catalogue's API returns, sorted so that two exports of the same commit
+    produce the same file.
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": source,
+        "catalogue": sorted(catalogue_map.catalogue(), key=lambda entry: entry["type"]),
+        "modules": {module: catalogue_map.processor(module)
+                    for module in sorted(catalogue_map.processors)},
+    }
+
+
+def prepare_output(output):
+    """
+    Make an empty output directory, replacing an earlier export.
+
+    A directory holding anything other than a previous export is left alone: better
+    to stop than to empty out a directory that turns out to be something else.
+    """
+    if output.exists() and any(output.iterdir()):
+        if not output.joinpath("manifest.json").exists():
+            raise RuntimeError("%s is not empty and does not look like an earlier catalogue "
+                               "export (it has no manifest.json), so it was left untouched" % output)
+        shutil.rmtree(output)
+    output.mkdir(parents=True, exist_ok=True)
+
+
+def copy_assets(output):
+    """Copy the files that are neither the page nor a stylesheet."""
+    for repository_path, bundle_path in ASSETS:
+        origin = PATH_ROOT.joinpath(repository_path)
+        if not origin.exists():
+            raise RuntimeError("the catalogue page needs %s, which does not exist" % repository_path)
+        destination = output.joinpath(bundle_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(origin, destination)
+
+
+def copy_stylesheets(output):
+    """
+    Copy 4CAT's own styling, so the published page looks like the catalogue inside
+    4CAT and keeps looking like it while the design is being worked on.
+
+    Which files that means is read from the stylesheets themselves: fourcat-new.css
+    names every part it is built from, and each of those may pull in more, down to
+    background images. Following that from the top means adding or removing a piece
+    of 4CAT's styling needs no change here. Everything must sit under the static
+    folder, so a reference pointing anywhere else stops the export rather than
+    publishing a page missing its styling.
+    """
+    copied = set()
+    queue = [PATH_STATIC.joinpath("css", name) for name in STYLESHEETS]
+
+    while queue:
+        origin = queue.pop().resolve()
+        if origin in copied:
+            continue
+        if not origin.exists():
+            raise RuntimeError("4CAT's styling refers to %s, which does not exist" % origin)
+        try:
+            place = origin.relative_to(PATH_STATIC)
+        except ValueError:
+            raise RuntimeError("4CAT's styling refers to %s, which is outside the static "
+                               "folder and so cannot be published" % origin)
+
+        copied.add(origin)
+        destination = output.joinpath("assets", place)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(origin, destination)
+
+        if origin.suffix == ".css":
+            for match in CSS_REFERENCE.finditer(origin.read_text(encoding="utf-8")):
+                reference = (match.group(1) or match.group(2) or "").strip()
+                if not reference or reference.startswith("data:"):
+                    continue
+                # A stylesheet pointing at another server would make every visitor's
+                # browser fetch part of this page from somewhere else, which is what
+                # publishing a self-contained copy is meant to avoid -- and which
+                # nobody would notice, because the page still looks right.
+                if reference.startswith(("http://", "https://", "//")):
+                    raise RuntimeError(
+                        "%s loads %s from another server. Everything this page needs has to be "
+                        "in 4CAT itself, so put a copy in webtool/static and point at that."
+                        % (place, reference))
+                queue.append(origin.parent.joinpath(reference))
+
+    return len(copied)
+
+
+def write_page(output):
+    """
+    Write the page, with the catalogue markup 4CAT's own page uses pasted into it.
+
+    Both pages read that markup from one file so they cannot drift apart, which only
+    holds while it stays plain HTML and while 4CAT's page really does use it. Both
+    are checked here, because either would otherwise fail quietly: a template tag
+    would be published as visible nonsense, and a page that stopped sharing the
+    markup would simply start describing something else.
+    """
+    body = SHARED_BODY.read_text(encoding="utf-8")
+    for syntax in ("{{", "{%", "{#"):
+        raise_at = body.find(syntax)
+        if raise_at != -1:
+            raise RuntimeError("%s contains template syntax (%s), but it has to be plain HTML: "
+                               "nothing here can fill it in. Anything needing a value from 4CAT "
+                               "belongs in %s instead." % (SHARED_BODY.name, syntax, LIVE_PAGE.name))
+
+    if SHARED_BODY.name not in LIVE_PAGE.read_text(encoding="utf-8"):
+        raise RuntimeError("%s no longer uses %s, so 4CAT's catalogue and the published one "
+                           "would no longer show the same thing" % (LIVE_PAGE.name, SHARED_BODY.name))
+
+    shell = SHELL.read_text(encoding="utf-8")
+    if BODY_MARKER not in shell:
+        raise RuntimeError("%s no longer contains %s, so there is nowhere to put the "
+                           "catalogue markup" % (SHELL.name, BODY_MARKER))
+
+    output.joinpath("index.html").write_text(shell.replace(BODY_MARKER, body), encoding="utf-8")
+
+
+def export(output, source):
+    """Write the whole bundle and return what should be reported about it."""
+    prepare_output(output)
+
+    with tempfile.TemporaryDirectory(prefix="4cat-catalogue-") as scratch:
+        catalogue_map = build_map(Path(scratch))
+        snapshot = build_snapshot(catalogue_map, source)
+
+    data_file = output.joinpath(DATA_FILE)
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n"
+    data_file.write_text(data, encoding="utf-8")
+
+    write_page(output)
+    stylesheets = copy_stylesheets(output)
+    copy_assets(output)
+    output.joinpath("manifest.json").write_text(json.dumps({
+        "format_version": SCHEMA_VERSION,
+        "fourcat_version": source["fourcat_version"],
+        "git_tag": source["git_tag"],
+        "git_commit": source["git_commit"],
+        "generated_at": source["generated_at"],
+        "data_file": DATA_FILE,
+    }, indent=2) + "\n", encoding="utf-8")
+
+    encoded = data.encode("utf-8")
+    return {
+        "modules": len(snapshot["catalogue"]),
+        "datasources": len([e for e in snapshot["catalogue"] if e["is_datasource"]]),
+        "stylesheets": stylesheets,
+        "bytes": len(encoded),
+        "gzipped": len(gzip.compress(encoded)),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--output", required=True, type=Path,
+                        help="directory to write the catalogue to")
+    parser.add_argument("--version", help="the 4CAT version this describes (default: the VERSION file)")
+    parser.add_argument("--tag", help="the release tag this describes (default: asked of git)")
+    parser.add_argument("--commit", help="the commit this describes (default: asked of git)")
+    parser.add_argument("--generated-at", help="timestamp to record (default: the commit's own date, "
+                                               "so re-exporting a release reproduces it exactly)")
+    arguments = parser.parse_args()
+
+    # only the first line of VERSION is the version; the rest of the file explains
+    # what it is for
+    version_file = PATH_ROOT.joinpath("VERSION")
+    source = {
+        "fourcat_version": arguments.version
+            or (version_file.read_text().splitlines()[0].strip() if version_file.exists() else "unknown"),
+        "git_tag": arguments.tag or git("describe", "--tags", "--always", default="unknown"),
+        "git_commit": arguments.commit or git("rev-parse", "HEAD", default="unknown"),
+        "generated_at": arguments.generated_at or git("show", "-s", "--format=%cI", "HEAD")
+            or datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        result = export(arguments.output, source)
+    except RuntimeError as e:
+        sys.exit("Nothing was published: %s" % e)
+
+    print("4CAT %s (tag %s, commit %s)" % (source["fourcat_version"], source["git_tag"], source["git_commit"][:8]))
+    print("%i modules, of which %i data sources" % (result["modules"], result["datasources"]))
+    print("%i styling files copied from 4CAT" % result["stylesheets"])
+    print("%s: %.1f kB, %.1f kB compressed, sha256 %s"
+          % (DATA_FILE, result["bytes"] / 1000, result["gzipped"] / 1000, result["sha256"]))
+    print("written to %s" % arguments.output.resolve())
+    print("look at it with: python -m http.server --directory %s" % arguments.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_module_catalogue_export.py
+++ b/tests/test_module_catalogue_export.py
@@ -1,0 +1,643 @@
+"""
+Tests for the static module catalogue export (helper-scripts/export_module_catalogue.py).
+
+The export publishes a page describing every data source and processor in a 4CAT
+release, to be served by an ordinary web server with no 4CAT behind it. Three things
+can go wrong quietly, and those are what these tests are mostly about:
+
+* the catalogue could come out short -- a module that failed to load, or that the
+  map could not read, would simply be absent, and a page listing 157 of 158 modules
+  looks exactly like a page listing all of them;
+* the published page could drift away from the one inside 4CAT, which is the whole
+  reason the two share their markup, their stylesheets and their JavaScript;
+* the page could claim to describe a 4CAT release when it describes somebody's work
+  in progress.
+
+So the export refuses to publish a partial, drifted or mislabelled result, and the
+tests below check that each of those refusals actually happens, as well as running
+one real export of this checkout and inspecting what it produced.
+"""
+import importlib.util
+import json
+import re
+import shutil
+
+from pathlib import Path
+
+import pytest
+
+PATH_ROOT = Path(__file__).resolve().parent.parent
+
+# Fixed provenance, so tests can check these exact values come out the other end.
+PROVENANCE = {
+    "kind": "release",
+    "fourcat_version": "9.99",
+    "release_tag": "v9.99",
+    "git_describe": "v9.99",
+    "git_commit": "0123456789abcdef0123456789abcdef01234567",
+    "generated_at": "2026-01-01T00:00:00+00:00",
+}
+
+
+@pytest.fixture(scope="module")
+def export():
+    """The export script. Loaded by path, because helper-scripts is not a package."""
+    path = PATH_ROOT.joinpath("helper-scripts", "export_module_catalogue.py")
+    spec = importlib.util.spec_from_file_location("export_module_catalogue", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def bundle(export, tmp_path_factory):
+    """One real export of this checkout, shared by every test that reads it."""
+    output = tmp_path_factory.mktemp("catalogue").joinpath("bundle")
+    export.export(output, dict(PROVENANCE))
+    return output
+
+
+@pytest.fixture(scope="module")
+def snapshot(bundle):
+    """The published data file."""
+    return json.loads(bundle.joinpath("data", "catalogue-v1.json").read_text(encoding="utf-8"))
+
+
+# --- helpers ---------------------------------------------------------------
+
+# A file a page or stylesheet loads as part of itself: a <link>, anything with a
+# src, or a url() in CSS. Deliberately not <a href>, which is somewhere a visitor
+# can choose to go rather than something the page fetches.
+RESOURCE = re.compile(
+    r"""<link\b[^>]*\bhref\s*=\s*["']([^"']+)["']"""
+    r"""|\bsrc\s*=\s*["']([^"']+)["']"""
+    r"""|url\(\s*["']?([^"')]+?)["']?\s*\)""",
+    re.IGNORECASE)
+
+
+def resources(text):
+    """Every file the given HTML or CSS loads as part of itself."""
+    found = set()
+    for match in RESOURCE.finditer(text):
+        reference = (match.group(1) or match.group(2) or match.group(3) or "").strip()
+        if reference and not reference.startswith("data:"):
+            found.add(reference)
+    return found
+
+
+def local_references(text):
+    """The resources that are expected to sit on this same server."""
+    return {reference.split("?")[0].split("#")[0] for reference in resources(text)
+            if not reference.startswith(("http://", "https://", "//", "#"))}
+
+
+def loaded_module_types(export, scratch, extensions):
+    """
+    The modules this checkout loads, with `extensions` saying which installed
+    extensions are switched on.
+
+    ModuleCollector gathers what it finds into dictionaries held on the class, and
+    only hands the instance its own copy once the walk has finished. Every loader in
+    the process therefore adds to one shared pile, and a second load can never come
+    back with fewer modules than the first -- comparing two loads without clearing
+    that pile silently compares a set with itself. So each call empties it first and
+    puts back exactly what was there afterwards.
+    """
+    collector = export.ModuleCollector
+    shared = ("workers", "processors", "datasources", "ignore")
+    saved = {name: getattr(collector, name) for name in shared}
+    collector.workers, collector.processors, collector.datasources, collector.ignore = {}, {}, {}, []
+    try:
+        config = export.ExportConfig(scratch)
+        config.settings["extensions.enabled"] = extensions
+        config.get("PATH_LOGS").mkdir(parents=True, exist_ok=True)
+        return set(collector(config=config).processors)
+    finally:
+        for name, value in saved.items():
+            setattr(collector, name, value)
+
+
+def fake_pages(export, monkeypatch, tmp_path, body="<p id=\"pc-search\">markup</p>",
+               live="{% include 'components/module-catalog-body.html' %}",
+               shell="<body>\n<!--CATALOGUE-BODY-->\n</body>"):
+    """Stand-ins for the three files the page is assembled from, so the checks that
+    guard them can be tried without touching the real ones."""
+    fragment = tmp_path.joinpath("module-catalog-body.html")
+    page = tmp_path.joinpath("module-catalog.html")
+    outer = tmp_path.joinpath("index.html")
+    for path, text in ((fragment, body), (page, live), (outer, shell)):
+        path.write_text(text, encoding="utf-8")
+    monkeypatch.setattr(export, "SHARED_BODY", fragment)
+    monkeypatch.setattr(export, "LIVE_PAGE", page)
+    monkeypatch.setattr(export, "SHELL", outer)
+
+
+def copy_of(bundle, tmp_path, name="bundle"):
+    """A throwaway copy of the exported bundle, to be broken in one specific way."""
+    copy = tmp_path.joinpath(name)
+    shutil.copytree(bundle, copy)
+    return copy
+
+
+def rewrite_json(path, change):
+    """Read a JSON file, let `change` alter it, and write it back."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    change(data)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class FakeLoader:
+    """A module loader that reports exactly what a test tells it to."""
+
+    def __init__(self, processors=(), missing=None):
+        self.processors = {name: type(name, (), {}) for name in processors}
+        self.missing_modules = missing or {}
+
+    def __call__(self, config=None):
+        return self
+
+
+# --- the catalogue must not come out short ---------------------------------
+
+def test_every_loaded_module_reaches_the_catalogue(export, bundle, snapshot, tmp_path):
+    """The published catalogue lists every module this checkout loads -- nothing is
+    dropped on the way from the loader, through the map, into the file."""
+    catalogue_map = export.build_map(tmp_path)
+    published = {entry["type"] for entry in snapshot["catalogue"]}
+    assert published == set(catalogue_map.processors)
+    assert len(published) == len(snapshot["catalogue"]), "a module is listed twice"
+
+
+def test_every_listed_module_has_its_full_details(snapshot):
+    """Opening any module in the catalogue has to find something to show."""
+    listed = {entry["type"] for entry in snapshot["catalogue"]}
+    assert set(snapshot["modules"]) == listed
+    for module_type, detail in snapshot["modules"].items():
+        assert detail is not None, "%s has no details" % module_type
+        assert detail["type"] == module_type
+
+
+def test_a_module_that_will_not_load_stops_the_export(export, monkeypatch, tmp_path):
+    monkeypatch.setattr(export, "ModuleCollector",
+                        FakeLoader(processors=["a"], missing={"numpy": ["processors.a"]}))
+    with pytest.raises(RuntimeError, match="could not be loaded"):
+        export.build_map(tmp_path)
+
+
+def test_a_module_the_map_cannot_read_stops_the_export(export, monkeypatch, tmp_path):
+    """A module can load and still fall out while the map reads it. The loader
+    reports nothing wrong in that case, so the export compares the two itself."""
+    class HalfBuiltMap:
+        def __init__(self, modules, config, logger=None):
+            self.processors = {"a": modules.processors["a"]}  # "b" fell out
+
+    monkeypatch.setattr(export, "ModuleCollector", FakeLoader(processors=["a", "b"]))
+    monkeypatch.setattr(export, "ProcessorMap", HalfBuiltMap)
+    with pytest.raises(RuntimeError, match="could not be read into the map") as raised:
+        export.build_map(tmp_path)
+    assert "b" in str(raised.value), "the export does not say which module went missing"
+
+
+def test_a_problem_reported_while_building_stops_the_export(export, monkeypatch, tmp_path):
+    """The map keeps going when a module's compatibility is miscalibrated, and says
+    so in the log. For a published catalogue that is not good enough."""
+    class ComplainingMap:
+        def __init__(self, modules, config, logger=None):
+            self.processors = dict(modules.processors)
+            logger.error("processor 'a' has a 'compatibility' that is str")
+
+    monkeypatch.setattr(export, "ModuleCollector", FakeLoader(processors=["a"]))
+    monkeypatch.setattr(export, "ProcessorMap", ComplainingMap)
+    with pytest.raises(RuntimeError, match="reported problems"):
+        export.build_map(tmp_path)
+
+
+# --- extensions are not published ------------------------------------------
+
+def test_the_loader_is_told_to_ignore_every_extension(export, tmp_path):
+    """Whatever is installed on the machine running the export, no extension is
+    enabled while the catalogue is built."""
+    config = export.ExportConfig(tmp_path)
+    assert config.get("extensions.enabled") == {}
+    assert config.get("PATH_EXTENSIONS") == PATH_ROOT.joinpath("config", "extensions")
+
+
+def test_installed_extensions_do_not_reach_the_catalogue(export, snapshot, tmp_path):
+    """
+    Where this machine has extensions installed, nothing they add is published.
+
+    What an extension adds is worked out by loading twice and comparing, rather than
+    by reading each module's own is_extension flag: that flag records where a module
+    was first come across, so a core module an extension happens to import is
+    labelled as the extension's.
+
+    Skipped where there is genuinely nothing to leave out, so that a pass always
+    means something was checked.
+    """
+    extensions_folder = export.ExportConfig(tmp_path).get("PATH_EXTENSIONS")
+    installed = ([path.name for path in extensions_folder.iterdir() if path.is_dir()]
+                 if extensions_folder.is_dir() else [])
+    if not installed:
+        pytest.skip("no extensions are installed here, so there is nothing to leave out")
+
+    everything = loaded_module_types(export, tmp_path, {name: {"enabled": True} for name in installed})
+    core = loaded_module_types(export, tmp_path, {})
+    from_extensions = everything - core
+    if not from_extensions:
+        pytest.skip("the installed extensions (%s) add no modules" % ", ".join(installed))
+
+    published = {entry["type"] for entry in snapshot["catalogue"]}
+    assert not (published & from_extensions), \
+        "these came from an extension and should not be published: %s" % sorted(published & from_extensions)
+    assert published == core, "the catalogue is not exactly this release's core modules"
+
+
+# --- the published data ----------------------------------------------------
+
+def test_the_data_file_says_what_it_is(snapshot, export):
+    assert snapshot["schema_version"] == export.SCHEMA_VERSION
+    assert set(snapshot) == {"schema_version", "source", "catalogue", "modules"}
+    assert snapshot["source"] == PROVENANCE
+
+
+def test_the_manifest_describes_the_bundle(bundle, snapshot, export):
+    """The manifest is what the site reads first, so it has to name the data file
+    and carry the provenance the export was given."""
+    manifest = json.loads(bundle.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert manifest["format_version"] == export.FORMAT_VERSION
+    assert manifest["data_schema_version"] == export.SCHEMA_VERSION == snapshot["schema_version"]
+    assert manifest["source"] == PROVENANCE
+    assert manifest["source"] == snapshot["source"], "the manifest and the data file disagree"
+    assert manifest["data_file"] == export.DATA_FILE
+    assert bundle.joinpath(manifest["data_file"]).exists()
+
+
+def test_the_data_file_is_sorted(snapshot):
+    """Sorted so that two releases can be compared by reading the difference."""
+    assert [entry["type"] for entry in snapshot["catalogue"]] == sorted(snapshot["modules"])
+    assert list(snapshot["modules"]) == sorted(snapshot["modules"])
+
+
+def test_two_exports_of_the_same_checkout_are_identical(export, tmp_path):
+    """Nothing about the machine or the moment leaks into the published files, so a
+    release can be exported again and checked against what was published."""
+    first, second = tmp_path.joinpath("first"), tmp_path.joinpath("second")
+    export.export(first, dict(PROVENANCE))
+    export.export(second, dict(PROVENANCE))
+    for name in ("data/catalogue-v1.json", "manifest.json", "index.html"):
+        assert first.joinpath(name).read_bytes() == second.joinpath(name).read_bytes(), \
+            "%s came out differently the second time" % name
+
+
+def test_a_module_entry_carries_what_the_page_shows(snapshot):
+    """The page draws each module from these, so an entry missing them would render
+    blank rather than fail."""
+    for entry in snapshot["catalogue"]:
+        assert entry["type"] and entry["title"]
+        for field in ("tags", "is_datasource", "is_filter", "description"):
+            assert field in entry, "%s has no %s" % (entry["type"], field)
+    for module_type, detail in snapshot["modules"].items():
+        for field in ("how_to_run", "followups", "output_shape"):
+            assert field in detail, "%s has no %s" % (module_type, field)
+
+
+# --- what is published has to be what it claims to be ----------------------
+
+def test_an_exactly_tagged_commit_is_published_as_a_release(export, monkeypatch):
+    monkeypatch.setattr(export, "git", lambda *arguments, default="": {
+        ("describe", "--exact-match", "--tags", "HEAD"): "v1.56",
+        ("describe", "--tags", "--always"): "v1.56",
+        ("rev-parse", "HEAD"): "a" * 40,
+    }.get(arguments, default))
+    source = export.describe_source()
+    assert source["kind"] == "release"
+    assert source["release_tag"] == "v1.56"
+
+
+def test_a_commit_after_a_tag_is_published_as_a_snapshot(export, monkeypatch):
+    """git describe answers "v1.55-145-ga6e11f52e" for a commit 145 after v1.55.
+    Reading a release tag out of that would put a version on the public page that
+    was never released, so a snapshot has no release tag at all."""
+    monkeypatch.setattr(export, "git", lambda *arguments, default="": {
+        ("describe", "--exact-match", "--tags", "HEAD"): "",   # git found no exact tag
+        ("describe", "--tags", "--always"): "v1.55-145-ga6e11f52e",
+        ("rev-parse", "HEAD"): "b" * 40,
+    }.get(arguments, default))
+    source = export.describe_source()
+    assert source["kind"] == "development_snapshot"
+    assert source["release_tag"] is None
+    assert source["git_describe"] == "v1.55-145-ga6e11f52e"
+
+
+def test_a_named_release_tag_is_taken_at_its_word(export, monkeypatch):
+    """A release build passes the tag, because a shallow checkout has no tags for
+    git to find and the release would otherwise be published as a snapshot."""
+    monkeypatch.setattr(export, "git", lambda *arguments, default="": {
+        ("describe", "--tags", "--always"): "unknown",
+        ("rev-parse", "HEAD"): "c" * 40,
+    }.get(arguments, default))
+    source = export.describe_source(release_tag="v1.56")
+    assert source["kind"] == "release"
+    assert source["release_tag"] == "v1.56"
+
+
+def test_the_page_says_which_release_it_is_showing(bundle):
+    """Both wordings live in the page, so it can name a release or own up to being
+    a snapshot without the export having to write different pages."""
+    page = bundle.joinpath("index.html").read_text(encoding="utf-8")
+    assert "Catalogue for 4CAT" in page
+    assert "Development snapshot" in page
+    assert "release_tag" in page and "kind" in page
+
+
+# --- the two catalogues must not drift apart -------------------------------
+
+def test_the_published_page_uses_4cats_own_catalogue_markup(export, bundle):
+    """The published page and the one inside 4CAT show the same thing because they
+    are built from the same markup, so it has to actually be in there."""
+    page = bundle.joinpath("index.html").read_text(encoding="utf-8")
+    fragment = export.SHARED_BODY.read_text(encoding="utf-8")
+    assert fragment.strip() in page
+    assert export.BODY_MARKER not in page, "the markup was never pasted in"
+    for element in ("pc-detail-body", "pc-search", "pc-tag", "pc-catalogue", "pc-count"):
+        assert element in page, "the page has no %s for the catalogue to draw into" % element
+
+
+def test_4cats_own_page_uses_the_shared_markup_too(export):
+    """The other half of the same promise: if 4CAT's page stopped including the
+    shared markup the two would drift apart without anything failing."""
+    live = export.LIVE_PAGE.read_text(encoding="utf-8")
+    assert export.SHARED_BODY.name in live
+    assert "pc-search" not in live, "4CAT's page has its own copy of the markup again"
+
+
+def test_template_syntax_in_the_shared_markup_stops_the_export(export, monkeypatch, tmp_path):
+    """Nothing fills in template tags for the published page, so they would be
+    published as visible nonsense."""
+    for syntax in ("{{ processor.type }}", "{% if x %}{% endif %}", "{# note #}"):
+        fake_pages(export, monkeypatch, tmp_path, body="<p>%s</p>" % syntax)
+        with pytest.raises(RuntimeError, match="plain HTML"):
+            export.write_page(tmp_path.joinpath("out"))
+
+
+def test_4cat_dropping_the_shared_markup_stops_the_export(export, monkeypatch, tmp_path):
+    fake_pages(export, monkeypatch, tmp_path, live="<p>a page of its own again</p>")
+    with pytest.raises(RuntimeError, match="no longer uses"):
+        export.write_page(tmp_path.joinpath("out"))
+
+
+def test_a_shell_with_nowhere_to_put_the_markup_stops_the_export(export, monkeypatch, tmp_path):
+    fake_pages(export, monkeypatch, tmp_path, shell="<body>nothing here</body>")
+    with pytest.raises(RuntimeError, match="nowhere to put"):
+        export.write_page(tmp_path.joinpath("out"))
+
+
+def test_the_markup_is_pasted_where_the_marker_was(export, monkeypatch, tmp_path):
+    fake_pages(export, monkeypatch, tmp_path, body="<p id=\"pc-search\">here</p>",
+               shell="<body>\nbefore\n<!--CATALOGUE-BODY-->\nafter\n</body>")
+    output = tmp_path.joinpath("out")
+    output.mkdir()
+    export.write_page(output)
+    page = output.joinpath("index.html").read_text(encoding="utf-8")
+    assert page.index("before") < page.index("here") < page.index("after")
+
+
+# --- 4CAT's styling comes along --------------------------------------------
+
+def test_the_styling_follows_4cats_own_list(export, bundle):
+    """The stylesheets to publish are read from the stylesheets themselves, so that
+    changing how 4CAT looks needs no change to the export. Everything the top-level
+    stylesheet names has to have come along."""
+    for name in export.STYLESHEETS:
+        assert bundle.joinpath("assets", "css", name).exists()
+    top = PATH_ROOT.joinpath("webtool", "static", "css", "fourcat-new.css").read_text(encoding="utf-8")
+    imported = local_references(top)
+    assert imported, "fourcat-new.css named no other stylesheets -- has it moved?"
+    for reference in imported:
+        assert bundle.joinpath("assets", "css", reference).exists(), "%s was left behind" % reference
+
+
+def test_a_stylesheet_loading_from_another_server_stops_the_export(export, monkeypatch, tmp_path):
+    """A published page fetching part of itself from somewhere else would still look
+    right, so nothing would draw attention to it."""
+    static = tmp_path.joinpath("static", "css")
+    static.mkdir(parents=True)
+    static.joinpath("main.css").write_text("@import url('other.css');", encoding="utf-8")
+    static.joinpath("other.css").write_text(
+        ".x { mask-image: url('https://example.org/logo.svg'); }", encoding="utf-8")
+    monkeypatch.setattr(export, "PATH_STATIC", tmp_path.joinpath("static"))
+    monkeypatch.setattr(export, "STYLESHEETS", ("main.css",))
+    with pytest.raises(RuntimeError, match="another server"):
+        export.copy_stylesheets(tmp_path.joinpath("out"))
+
+
+def test_a_stylesheet_reaching_outside_the_static_folder_stops_the_export(export, monkeypatch, tmp_path):
+    static = tmp_path.joinpath("static", "css")
+    static.mkdir(parents=True)
+    tmp_path.joinpath("elsewhere.css").write_text("/* not publishable */", encoding="utf-8")
+    static.joinpath("main.css").write_text("@import url('../../elsewhere.css');", encoding="utf-8")
+    monkeypatch.setattr(export, "PATH_STATIC", tmp_path.joinpath("static"))
+    monkeypatch.setattr(export, "STYLESHEETS", ("main.css",))
+    with pytest.raises(RuntimeError, match="outside the static folder"):
+        export.copy_stylesheets(tmp_path.joinpath("out"))
+
+
+def test_styling_is_followed_all_the_way_down(export, monkeypatch, tmp_path):
+    """A stylesheet can name another, which can name an image; all of it has to come
+    along, and a loop between two stylesheets must not hang the export."""
+    static = tmp_path.joinpath("static")
+    static.joinpath("css").mkdir(parents=True)
+    static.joinpath("img").mkdir()
+    static.joinpath("img", "logo.svg").write_text("<svg/>", encoding="utf-8")
+    static.joinpath("css", "main.css").write_text("@import url('deep.css');", encoding="utf-8")
+    static.joinpath("css", "deep.css").write_text(
+        "@import url('main.css'); .x { background: url('../img/logo.svg'); }", encoding="utf-8")
+    monkeypatch.setattr(export, "PATH_STATIC", static)
+    monkeypatch.setattr(export, "STYLESHEETS", ("main.css",))
+
+    output = tmp_path.joinpath("out")
+    assert export.copy_stylesheets(output) == 3
+    assert output.joinpath("assets", "css", "deep.css").exists()
+    assert output.joinpath("assets", "img", "logo.svg").exists()
+
+
+def test_missing_styling_stops_the_export(export, monkeypatch, tmp_path):
+    static = tmp_path.joinpath("static", "css")
+    static.mkdir(parents=True)
+    static.joinpath("main.css").write_text("@import url('gone.css');", encoding="utf-8")
+    monkeypatch.setattr(export, "PATH_STATIC", tmp_path.joinpath("static"))
+    monkeypatch.setattr(export, "STYLESHEETS", ("main.css",))
+    with pytest.raises(RuntimeError, match="does not exist"):
+        export.copy_stylesheets(tmp_path.joinpath("out"))
+
+
+# --- the bundle stands on its own ------------------------------------------
+
+def test_the_bundle_contains_everything_it_points_at(bundle):
+    """Every file the page and its stylesheets name is in the bundle, and none of
+    them reaches outside it -- which is what lets the folder be copied anywhere."""
+    problems = []
+    for source in [bundle.joinpath("index.html"), *sorted(bundle.rglob("*.css"))]:
+        for reference in local_references(source.read_text(encoding="utf-8")):
+            target = source.parent.joinpath(reference).resolve()
+            where = source.relative_to(bundle)
+            if bundle.resolve() not in target.parents:
+                problems.append("%s reaches outside the bundle for %s" % (where, reference))
+            elif not target.exists():
+                problems.append("%s wants %s, which is not in the bundle" % (where, reference))
+    assert not problems, "\n".join(problems)
+
+
+def test_the_bundle_loads_nothing_from_a_4cat(bundle):
+    """
+    Nothing the page loads as part of itself may come from a 4CAT, an internal
+    address, or anywhere else this bundle does not contain -- except the typefaces,
+    which are loaded the way 4CAT itself loads them.
+
+    Links a visitor can click are a different matter and are not checked here; the
+    page is meant to link out to the 4CAT site and to the release it describes.
+    """
+    allowed = ("https://fonts.googleapis.com", "https://fonts.gstatic.com")
+    for source in [bundle.joinpath("index.html"), *sorted(bundle.rglob("*.css")),
+                   *sorted(bundle.rglob("*.js"))]:
+        for reference in resources(source.read_text(encoding="utf-8")):
+            if reference.startswith(("http://", "https://", "//")):
+                assert reference.startswith(allowed), \
+                    "%s loads %s" % (source.relative_to(bundle), reference)
+
+
+def test_the_published_page_does_not_call_a_4cat_api(bundle):
+    """
+    The page tells the renderer to read the exported file instead of asking a 4CAT.
+
+    The renderer still carries the live API address, because it is 4CAT's own file
+    and that is what it falls back on inside the application -- so the check is that
+    the page overrides it, not that the address is absent.
+    """
+    page = bundle.joinpath("index.html").read_text(encoding="utf-8")
+    assert "/api/processor-map" not in page
+    assert "MODULE_CATALOG_SOURCE" in page
+    for source in sorted(bundle.rglob("*.css")):
+        assert "/api/" not in source.read_text(encoding="utf-8")
+
+
+def test_the_page_starts_from_the_manifest(bundle, export):
+    """The page has no API to fall back on. It reads the manifest first and follows
+    it to the data, rather than assuming a filename the export might change."""
+    page = bundle.joinpath("index.html").read_text(encoding="utf-8")
+    assert export.MANIFEST_FILE in page
+    assert "MODULE_CATALOG_SOURCE" in page, "the page never says where to get its data"
+    assert "manifest.data_file" in page, "the page does not follow the manifest to the data"
+
+
+def test_the_renderer_is_4cats_own(bundle):
+    """The published page runs the same JavaScript as 4CAT, rather than a copy."""
+    published = bundle.joinpath("assets", "catalogue.js").read_bytes()
+    assert published == PATH_ROOT.joinpath("webtool", "static", "js", "module-catalog.js").read_bytes()
+
+
+# --- the finished bundle is read back before it counts as published --------
+
+def test_the_page_and_the_export_must_agree_on_versions(export, bundle, tmp_path, monkeypatch):
+    """The page states which versions it can read and the export checks its own
+    output against that, so a bundle the published page cannot read is never
+    written -- whichever of the two moved."""
+    for attribute, expected in (("FORMAT_VERSION", "manifest version"), ("SCHEMA_VERSION", "data version")):
+        copy = copy_of(bundle, tmp_path, attribute)
+        monkeypatch.setattr(export, attribute, 99)
+        with pytest.raises(RuntimeError, match=expected):
+            export.check_bundle(copy)
+        monkeypatch.undo()
+
+
+def test_a_manifest_pointing_at_nothing_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    rewrite_json(copy.joinpath("manifest.json"),
+                 lambda data: data.update(data_file="data/not-here.json"))
+    with pytest.raises(RuntimeError, match="not in the bundle"):
+        export.check_bundle(copy)
+
+
+def test_a_manifest_pointing_outside_the_bundle_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    rewrite_json(copy.joinpath("manifest.json"),
+                 lambda data: data.update(data_file="../somewhere-else.json"))
+    with pytest.raises(RuntimeError, match="not inside the bundle"):
+        export.check_bundle(copy)
+
+
+def test_a_module_without_details_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    rewrite_json(copy.joinpath("data", "catalogue-v1.json"),
+                 lambda data: data["modules"].pop(data["catalogue"][0]["type"]))
+    with pytest.raises(RuntimeError, match="listed but has no details"):
+        export.check_bundle(copy)
+
+
+def test_details_for_a_module_nobody_can_find_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    rewrite_json(copy.joinpath("data", "catalogue-v1.json"),
+                 lambda data: data["modules"].update({"not-in-the-catalogue": {"type": "x"}}))
+    with pytest.raises(RuntimeError, match="not listed"):
+        export.check_bundle(copy)
+
+
+def test_a_module_listed_twice_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    rewrite_json(copy.joinpath("data", "catalogue-v1.json"),
+                 lambda data: data["catalogue"].append(dict(data["catalogue"][0])))
+    with pytest.raises(RuntimeError, match="more than once"):
+        export.check_bundle(copy)
+
+
+def test_a_manifest_disagreeing_with_the_data_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    rewrite_json(copy.joinpath("manifest.json"),
+                 lambda data: data.update(source=dict(data["source"], git_commit="f" * 40)))
+    with pytest.raises(RuntimeError, match="disagree about where this came from"):
+        export.check_bundle(copy)
+
+
+def test_template_syntax_reaching_the_finished_page_stops_the_export(export, bundle, tmp_path):
+    """Belt and braces: the markup is checked before it is pasted in, and the
+    finished page is checked again after."""
+    copy = copy_of(bundle, tmp_path)
+    page = copy.joinpath("index.html")
+    page.write_text(page.read_text(encoding="utf-8") + "\n<p>{{ leftover }}</p>", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="nothing will fill in"):
+        export.check_bundle(copy)
+
+
+def test_a_file_missing_from_the_bundle_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    copy.joinpath("assets", "css", "module-catalog.css").unlink()
+    with pytest.raises(RuntimeError, match="not in the bundle"):
+        export.check_bundle(copy)
+
+
+def test_a_renderer_that_will_not_run_stops_the_export(export, bundle, tmp_path):
+    copy = copy_of(bundle, tmp_path)
+    copy.joinpath("assets", "catalogue.js").write_text("   \n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="empty"):
+        export.check_bundle(copy)
+
+
+# --- writing the output directory ------------------------------------------
+
+def test_an_earlier_export_is_replaced(export, tmp_path):
+    output = tmp_path.joinpath("bundle")
+    output.mkdir()
+    output.joinpath("manifest.json").write_text("{}", encoding="utf-8")
+    output.joinpath("stale.json").write_text("from a previous release", encoding="utf-8")
+    export.prepare_output(output)
+    assert not output.joinpath("stale.json").exists()
+
+
+def test_a_directory_that_is_not_an_export_is_left_alone(export, tmp_path):
+    """Pointing the export at the wrong directory should not empty it."""
+    output = tmp_path.joinpath("someones-work")
+    output.mkdir()
+    output.joinpath("notes.txt").write_text("keep me", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="left untouched"):
+        export.prepare_output(output)
+    assert output.joinpath("notes.txt").read_text(encoding="utf-8") == "keep me"

--- a/tests/test_module_catalogue_export.py
+++ b/tests/test_module_catalogue_export.py
@@ -341,6 +341,27 @@ def test_a_named_release_tag_is_taken_at_its_word(export, monkeypatch):
     assert source["release_tag"] == "v1.56"
 
 
+def test_provenance_can_be_supplied_rather_than_asked_of_git(export, monkeypatch):
+    """
+    A release is exported inside a container built from a shallow checkout, where git
+    knows almost nothing -- no tags, and sometimes no repository at all. Everything
+    recorded about the source can therefore be passed in instead, worked out where
+    git does have the full history.
+    """
+    monkeypatch.setattr(export, "git", lambda *arguments, default="": default)
+    source = export.describe_source(version="1.56", release_tag="v1.56", commit="d" * 40,
+                                    generated_at="2026-07-29T15:41:03+02:00",
+                                    git_describe="v1.56")
+    assert source == {
+        "kind": "release",
+        "fourcat_version": "1.56",
+        "release_tag": "v1.56",
+        "git_describe": "v1.56",
+        "git_commit": "d" * 40,
+        "generated_at": "2026-07-29T15:41:03+02:00",
+    }
+
+
 def test_the_page_says_which_release_it_is_showing(bundle):
     """Both wordings live in the page, so it can name a release or own up to being
     a snapshot without the export having to write different pages."""

--- a/webtool/static/css/components/site-header.css
+++ b/webtool/static/css/components/site-header.css
@@ -36,8 +36,6 @@
     margin-right: var(--spacing-smaller);
     background: var(--fourcat-accent);
     mask-image: url('../../img/4cat-heads-header.svg');
-    /* for testing - need HTTP image */
-    mask-image: url('https://4cat.digitalmethods.net/static/img/4cat-heads.svg');
     mask-size: cover;
     content: '';
     animation: .2s;

--- a/webtool/static/js/module-catalog.js
+++ b/webtool/static/js/module-catalog.js
@@ -1,17 +1,18 @@
 /* Module catalogue.
  *
- * A thin reactive client over the /api/processor-map/* endpoints: browse/search
- * modules, then open one to see "how to run this" (the dataset it needs and the
- * sensible ways to get there from a data source) and "what can run on this" (the
- * follow-up processors and filters its output unlocks). Holds no compatibility
- * logic itself -- that all lives in common/lib/processor_map.py; this file only
- * fetches what that computed and lays it out.
+ * Browse/search every data source and processor, then open one to see "how to run
+ * this" (the dataset it needs and the sensible ways to get there from a data
+ * source) and "what can run on this" (the follow-up processors and filters its
+ * output unlocks). Holds no compatibility logic itself -- that all lives in
+ * common/lib/processor_map.py; this file only lays out what that computed.
+ *
+ * Where the data comes from is not decided here (see SOURCE below), so the same
+ * renderer serves the live application and the published static catalogue.
  */
 (function () {
   "use strict";
 
-  const API = "/api/processor-map";
-  let CATALOGUE = [];   // every processor, as returned by the catalogue endpoint
+  let CATALOGUE = [];   // every module, as returned by the catalogue source
   const TITLE = {};     // processor type -> display title, so links can show names not ids
   let BROWSE_PLACEHOLDER = "";  // detail pane's empty state, kept so back/forward can restore it
 
@@ -29,29 +30,41 @@
     return response.json();
   }
 
+  // Where the catalogue data comes from, and how a module is addressed in the URL.
+  // The live application uses the default below and reads the API. The published
+  // static catalogue has no API, so its page defines window.MODULE_CATALOG_SOURCE
+  // before loading this file: it serves the same data from an exported JSON file
+  // and addresses modules with ?module=<type>. Everything after this point is
+  // identical in both.
+  const API = "/api/processor-map";
+  const SOURCE = window.MODULE_CATALOG_SOURCE || {
+    loadCatalogue: async () => (await getJSON(`${API}/catalogue`)).processors || [],
+    loadModule: type => getJSON(`${API}/processor/${encodeURIComponent(type)}`),
+    initialModule: () => (document.getElementById("pc-page").dataset.initialProcessor || "").trim(),
+    urlForModule: type => `/module-catalog/${encodeURIComponent(type)}`
+  };
+
   // On load: pull the whole catalogue once, remember every title, wire up the search
   // box and category dropdown, and draw the list. Everything after this is redrawing.
   // When the page is a deep link, the selected processor is fetched and drawn first --
   // its request goes out alongside the catalogue's, and its detail paints before the grid.
   async function init() {
-    const initial = (document.getElementById("pc-page").dataset.initialProcessor || "").trim();
+    const initial = SOURCE.initialModule();
 
     // On a deep link, start the selected processor's request right away -- in parallel with
     // the larger catalogue request rather than queued behind it -- so its content is ready
     // as soon as possible. Pre-caught to null so a bad type raises no unhandled rejection;
     // showDetail then treats null as "not found".
-    const detailPromise = initial
-      ? getJSON(`${API}/processor/${encodeURIComponent(initial)}`).catch(() => null)
-      : null;
+    const detailPromise = initial ? Promise.resolve(SOURCE.loadModule(initial)).catch(() => null) : null;
 
-    let data;
+    let modules;
     try {
-      data = await getJSON(`${API}/catalogue`);
+      modules = await SOURCE.loadCatalogue();
     } catch (e) {
-      document.getElementById("pc-loading").textContent = "Could not load processors.";
+      document.getElementById("pc-loading").textContent = "Could not load modules.";
       return;
     }
-    CATALOGUE = (data.processors || []).slice().sort((a, b) => (a.title || a.type).localeCompare(b.title || b.type));
+    CATALOGUE = modules.slice().sort((a, b) => (a.title || a.type).localeCompare(b.title || b.type));
     CATALOGUE.forEach(p => { TITLE[p.type] = p.title || p.type; });
 
     populateTags();
@@ -71,7 +84,7 @@
       else document.getElementById("pc-detail-body").innerHTML = BROWSE_PLACEHOLDER;
     });
 
-    // If the page was opened as a deep link (/module-catalog/<type>), draw that
+    // If the page was opened as a deep link to one module, draw that
     // processor before the browse grid -- but only if it really exists, so a stale or
     // mistyped link just falls through to the browse view. Its request is already in
     // flight (detailPromise) and TITLE is now ready for its follow-up chips. "replace"
@@ -152,7 +165,7 @@
     window.scrollTo({ top: 0, behavior: "smooth" });
     let info;
     try {
-      info = await (infoPromise || getJSON(`${API}/processor/${encodeURIComponent(type)}`));
+      info = await (infoPromise || SOURCE.loadModule(type));
     } catch (e) {
       body.innerHTML = '<p class="banner">Could not load this processor.</p>';
       return;
@@ -166,7 +179,7 @@
     // share exactly what they are looking at. "push" adds a history entry (a normal
     // click); "replace" rewrites the current one (first load, where the URL is already
     // right); "none" leaves it alone (a back/forward already moved the URL for us).
-    const url = `/module-catalog/${encodeURIComponent(type)}`;
+    const url = SOURCE.urlForModule(type);
     if (urlMode === "push") history.pushState({ pcType: type }, "", url);
     else if (urlMode === "replace") history.replaceState({ pcType: type }, "", url);
     body.querySelectorAll("[data-type]").forEach(el =>
@@ -301,6 +314,20 @@
     return next || '<p class="pc-muted">Nothing runs on this output.</p>';
   }
 
+  // A module's icon, following the same convention as the module-icon template: a
+  // name starting with "brand-" is a Font Awesome brand icon (the prefix is dropped
+  // and the brand style used), anything else is an ordinary one, and a module with
+  // no icon of its own gets the generic puzzle piece.
+  function iconHtml(name) {
+    let icon = name || "puzzle-piece";
+    let style = "fa";
+    if (icon.startsWith("brand-")) {
+      style = "fab";
+      icon = icon.slice(6);
+    }
+    return `<i class="${style} fa-fw fa-${esc(icon)}" aria-hidden="true"></i> `;
+  }
+
   // Render a references-style string: turn any [text](url) markdown links into anchors,
   // escaping everything else. Plain citations (no link) pass through unchanged.
   function mdLinks(s) {
@@ -343,7 +370,7 @@
 
     // the first tag is the category (shown below), so chip only the rest next to the title
     const tags = (info.tags || []).slice(1).map(t => `<span class="pc-tag">${esc(t)}</span>`).join("");
-    const icon = info.icon ? `<i class="fa fa-fw fa-${esc(info.icon)}" aria-hidden="true"></i> ` : "";
+    const icon = iconHtml(info.icon);
     const references = (info.references || []).length
       ? `<div class="pc-refs">${info.references.map(r => `<span>${mdLinks(r)}</span>`).join("")}</div>` : "";
     const foot = (produces || references)

--- a/webtool/static/module-catalog/index.html
+++ b/webtool/static/module-catalog/index.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>4CAT data sources &amp; processors</title>
+<meta name="description" content="Every data source and processor in an official 4CAT release: what each one does, the dataset it needs, and what can run on its output.">
+
+<!-- The one request this page makes to another server. 4CAT's own pages load
+     their typefaces from Google Fonts the same way; serving the font files from
+     this bundle instead would keep every visitor's request on this site. Still to
+     be decided. -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chivo:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="assets/fontawesome/css/fontawesome.css">
+<link rel="stylesheet" href="assets/fontawesome/css/solid.css">
+<link rel="stylesheet" href="assets/fontawesome/css/brands.css">
+<link rel="stylesheet" href="assets/css/fourcat-new.css">
+<link rel="stylesheet" href="assets/css/module-catalog.css">
+</head>
+
+<!-- The body class and the #main-content wrapper below are what 4CAT's stylesheet
+     hangs its page styling on, so this page keeps them and gets the same look as
+     the catalogue inside 4CAT. The site header is a plain version of 4CAT's own:
+     there is nothing to log in to here, so it carries no navigation into an
+     application. -->
+<body class="plain-page module-catalog">
+
+<section id="header-container">
+    <header id="site-header">
+        <section class="header-orientation">
+            <div class="site-title"><a href="https://4cat.nl/">4CAT</a></div>
+            <nav class="main-navigation">
+                <ul>
+                    <li><a href="https://4cat.nl/">About 4CAT</a></li>
+                    <li><a href="https://github.com/digitalmethodsinitiative/4cat">Source code</a></li>
+                </ul>
+            </nav>
+        </section>
+    </header>
+</section>
+
+<article id="main-content">
+    <h1>Data sources &amp; processors</h1>
+    <p>Every data source and processor in an official 4CAT release: what each one does,
+       the kind of dataset it needs, and what you can run on its output.</p>
+    <p id="pc-provenance" class="pc-provenance"></p>
+
+    <article id="pc-page">
+<!--CATALOGUE-BODY-->
+    </article>
+</article>
+
+<script>
+/* Where this page gets its catalogue data.
+ *
+ * There is no 4CAT application behind this page, so instead of asking a running
+ * 4CAT it reads one file written when the release was published, and puts the
+ * open module in the address as ?module=<type> so links work on any web server
+ * without special configuration. The script loaded below is the same file 4CAT
+ * itself uses to draw the catalogue; only this object differs. */
+window.MODULE_CATALOG_SOURCE = (function () {
+    "use strict";
+
+    const DATA_FILE = "data/catalogue-v1.json";
+    const SUPPORTED_SCHEMA = 1;
+    let pending = null;
+
+    // Read the data once, however many times it is asked for. A file written to a
+    // newer contract than this page understands is refused outright rather than
+    // drawn with pieces silently missing.
+    function snapshot() {
+        if (!pending) {
+            pending = fetch(DATA_FILE).then(function (response) {
+                if (!response.ok) throw new Error("HTTP " + response.status);
+                return response.json();
+            }).then(function (data) {
+                if (data.schema_version !== SUPPORTED_SCHEMA)
+                    throw new Error("catalogue data version " + data.schema_version + " is not supported by this page");
+                showProvenance(data.source || {});
+                return data;
+            });
+        }
+        return pending;
+    }
+
+    // Say which 4CAT release this catalogue describes, so it is clear the page
+    // documents an official release rather than somebody's running installation.
+    function showProvenance(source) {
+        const element = document.getElementById("pc-provenance");
+        if (!element) return;
+        const commit = String(source.git_commit || "");
+        element.textContent = "4CAT version " + (source.fourcat_version || "unknown")
+            + ". Extensions are not included. ";
+        if (commit) {
+            const link = document.createElement("a");
+            link.href = "https://github.com/digitalmethodsinitiative/4cat/commit/" + encodeURIComponent(commit);
+            link.textContent = "Commit " + commit.slice(0, 8);
+            element.appendChild(link);
+        }
+    }
+
+    return {
+        loadCatalogue: async () => (await snapshot()).catalogue || [],
+        loadModule: async type => ((await snapshot()).modules || {})[type] || null,
+        initialModule: () => (new URLSearchParams(window.location.search).get("module") || "").trim(),
+        urlForModule: type => "?module=" + encodeURIComponent(type)
+    };
+})();
+</script>
+<script src="assets/catalogue.js"></script>
+</body>
+</html>

--- a/webtool/static/module-catalog/index.html
+++ b/webtool/static/module-catalog/index.html
@@ -64,42 +64,66 @@
 window.MODULE_CATALOG_SOURCE = (function () {
     "use strict";
 
-    const DATA_FILE = "data/catalogue-v1.json";
-    const SUPPORTED_SCHEMA = 1;
+    const MANIFEST_FILE = "manifest.json";
+
+    // What this page can read. The first is the shape of the bundle -- that there
+    // is a manifest and what it holds; the second is the shape of the module data
+    // it points at. They are separate so that a page can tell "I do not understand
+    // this bundle at all" apart from "I found the data but cannot read it", and
+    // refuse either instead of drawing half a catalogue. The export checks these
+    // against what it writes, so a mismatch is caught before anything is published.
+    const SUPPORTED_MANIFEST = 2;
+    const SUPPORTED_DATA = 1;
+
     let pending = null;
 
-    // Read the data once, however many times it is asked for. A file written to a
-    // newer contract than this page understands is refused outright rather than
-    // drawn with pieces silently missing.
+    async function get(file) {
+        const response = await fetch(file);
+        if (!response.ok) throw new Error(file + ": HTTP " + response.status);
+        return response.json();
+    }
+
+    // Read the bundle once, however many times it is asked for: the manifest first,
+    // since that says which data file to load and which release this describes.
     function snapshot() {
         if (!pending) {
-            pending = fetch(DATA_FILE).then(function (response) {
-                if (!response.ok) throw new Error("HTTP " + response.status);
-                return response.json();
-            }).then(function (data) {
-                if (data.schema_version !== SUPPORTED_SCHEMA)
-                    throw new Error("catalogue data version " + data.schema_version + " is not supported by this page");
-                showProvenance(data.source || {});
-                return data;
+            pending = get(MANIFEST_FILE).then(function (manifest) {
+                if (manifest.format_version !== SUPPORTED_MANIFEST)
+                    throw new Error("this catalogue was published in format " + manifest.format_version
+                        + ", which this page cannot read");
+                showProvenance(manifest.source || {});
+                return get(manifest.data_file).then(function (data) {
+                    if (data.schema_version !== SUPPORTED_DATA)
+                        throw new Error("the module data is version " + data.schema_version
+                            + ", which this page cannot read");
+                    return data;
+                });
             });
         }
         return pending;
     }
 
-    // Say which 4CAT release this catalogue describes, so it is clear the page
-    // documents an official release rather than somebody's running installation.
+    // Say exactly what this catalogue describes. A released 4CAT is named by its
+    // release; anything else is a snapshot of work in progress and says so, rather
+    // than borrowing the last release's number and looking official.
     function showProvenance(source) {
         const element = document.getElementById("pc-provenance");
         if (!element) return;
         const commit = String(source.git_commit || "");
-        element.textContent = "4CAT version " + (source.fourcat_version || "unknown")
-            + ". Extensions are not included. ";
+
+        element.textContent = source.kind === "release"
+            ? "Catalogue for 4CAT " + (source.release_tag || source.fourcat_version) + ". "
+            : "Development snapshot of 4CAT " + (source.fourcat_version || "unknown")
+              + " — not a released version. ";
+
         if (commit) {
             const link = document.createElement("a");
             link.href = "https://github.com/digitalmethodsinitiative/4cat/commit/" + encodeURIComponent(commit);
             link.textContent = "Commit " + commit.slice(0, 8);
             element.appendChild(link);
+            element.appendChild(document.createTextNode(". "));
         }
+        element.appendChild(document.createTextNode("Extensions are not included."));
     }
 
     return {

--- a/webtool/templates/components/module-catalog-body.html
+++ b/webtool/templates/components/module-catalog-body.html
@@ -1,0 +1,32 @@
+<!-- The inside of the module catalogue: the detail panel, the search and filter
+     bar, and the area the module cards are drawn into.
+
+     Two pages use this file: the catalogue inside 4CAT, and the published
+     catalogue on the 4CAT website, which has no Flask behind it and copies these
+     contents straight into its own page. So everything here must be plain HTML,
+     with no template tags or variables; the export refuses to publish if it finds
+     any. Anything needing a value from Flask belongs in module-catalog.html. -->
+<section id="pc-detail">
+    <div id="pc-detail-body">
+        <p class="pc-placeholder">Select a data source or processor below to see how to run it and what it unlocks.</p>
+    </div>
+</section>
+
+<nav class="view-controls block" id="pc-controls">
+    <h2 class="pc-browse-title">Browse data sources &amp; processors</h2>
+    <form onsubmit="return false">
+        <ul>
+            <li><input id="pc-search" aria-label="Search data sources &amp; processors" placeholder="Search data sources &amp; processors…" autocomplete="off" spellcheck="false"></li>
+            <li>
+                <select id="pc-tag" aria-label="Filter by tag">
+                    <option value="">All tags</option>
+                </select>
+            </li>
+            <li><span id="pc-count" class="pc-count"></span></li>
+        </ul>
+    </form>
+</nav>
+
+<section id="pc-catalogue">
+    <p class="banner" id="pc-loading">Loading modules…</p>
+</section>

--- a/webtool/templates/components/processor-card-actions.html
+++ b/webtool/templates/components/processor-card-actions.html
@@ -1,7 +1,7 @@
 <nav class="quick-links">
     <ul class="module-actions processor-actions">
         <li class="button-secondary">
-            <a href="{{ url_for('misc.module_catalog') }}/{{ processor.type }}" x-tooltip="More information about this processor"><i class="fa-solid fa-circle-info"></i></a>
+            <a href="{{ url_for('misc.module_catalog', module_type=processor.type) }}" x-tooltip="More information about this processor"><i class="fa-solid fa-circle-info"></i></a>
         </li>
         <li class="button-secondary">
             <a href="{{ processor.get_repo_link(__config) }}" target="_blank" x-tooltip="View processor code"><i class="fa-brands fa-github"></i></a>

--- a/webtool/templates/components/processor-card.html
+++ b/webtool/templates/components/processor-card.html
@@ -31,11 +31,11 @@
                     <dt>Follow-ups</dt>
                     {% if processor.compatibility.preferred_followups %}
                         {% for followup in (processor.compatibility.preferred_followups|list)[:3] %}
-                            <a href="{{ url_for('misc.module_catalog') }}/{{ followup }}"><dd>{{ followup }}</dd></a>
+                            <a href="{{ url_for('misc.module_catalog', module_type=followup) }}"><dd>{{ followup }}</dd></a>
                         {% endfor %}
                     {% endif %}
                     <ul>
-                        <li class="button-secondary"><a href="{{ url_for('misc.module_catalog') }}/{{ processor.type }}">See all</a></li>
+                        <li class="button-secondary"><a href="{{ url_for('misc.module_catalog', module_type=processor.type) }}">See all</a></li>
                     </ul>
                 </div>
                 {% endif %}

--- a/webtool/templates/components/user-inputs/datasource-select.html
+++ b/webtool/templates/components/user-inputs/datasource-select.html
@@ -23,5 +23,5 @@
                 :class="{ disabled: !datasource }"
                 x-tooltip="Data source info"
                 x-init="$nextTick(() => { const upd = () => { const id = $el.getAttribute('aria-describedby'); if (id) document.getElementById(id).textContent = infoText || 'Data source info'; }; upd(); $watch('datasource', upd); })"
-        ><a :href="datasource ? '{{ url_for('misc.module_catalog') }}/' + datasource : null"><i class="fa-solid fa-circle-info"></i></a></li></ul>
+        ><a :href="datasource ? '{{ url_for('misc.module_catalog') }}' + datasource : null"><i class="fa-solid fa-circle-info"></i></a></li></ul>
 </div>

--- a/webtool/templates/module-catalog.html
+++ b/webtool/templates/module-catalog.html
@@ -8,30 +8,7 @@
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/module-catalog.css') }}">
 
 <article id="pc-page" data-initial-processor="{{ module_type|default('', true) }}">
-    <section id="pc-detail">
-        <div id="pc-detail-body">
-            <p class="pc-placeholder">Select a data source or processor below to see how to run it and what it unlocks.</p>
-        </div>
-    </section>
-
-    <nav class="view-controls block" id="pc-controls">
-        <h2 class="pc-browse-title">Browse data sources & processors</h2>
-        <form onsubmit="return false">
-            <ul>
-                <li><input id="pc-search" aria-label="Search data sources & processors" placeholder="Search data sources & processors…" autocomplete="off" spellcheck="false"></li>
-                <li>
-                    <select id="pc-tag" aria-label="Filter by tag">
-                        <option value="">All tags</option>
-                    </select>
-                </li>
-                <li><span id="pc-count" class="pc-count"></span></li>
-            </ul>
-        </form>
-    </nav>
-
-    <section id="pc-catalogue">
-        <p class="banner" id="pc-loading">Loading modules…</p>
-    </section>
+{% include 'components/module-catalog-body.html' %}
 </article>
 
 <script type="text/javascript" src="{{ url_for('static', filename='js/module-catalog.js') }}"></script>


### PR DESCRIPTION
## Summary

Publishes the 4CAT module catalogue as a static site, generated from 4CAT itself so the public page and the in-app one cannot drift apart. Now live at https://4cat.nl/catalog/.

Three parts:

- **An exporter** (`helper-scripts/export_module_catalogue.py`) that writes a  self-contained bundle — page, styles, renderer, icons and one JSON file — servable by any static web server. No 4CAT, no API and no database behind it.
- **A shared renderer.** The live catalogue and the published one now use one JavaScript file, one markup fragment, and 4CAT's real stylesheets (discovered by following `fourcat-new.css`'s own imports, so the catalogue tracks the redesign without anyone updating the exporter).
- **A release job** that runs on `release: published`, exports from the image that was just pushed, and opens a PR against `4cat-site` replacing `public/catalog/`.

## The details

- `manifest.json` is the bundle entry point, per a contract agreed with `4cat-site` and written up in `docs/module-catalog-export-contract.md`.
- Provenance is truthful: a release is only claimed when the commit is exactly tagged, or when CI names the tag. Anything else publishes as a development snapshot and says so on the catalog page.
- The export validates its own output and fails rather than publishing a partial or drifted bundle — should refuse if the two catalogues stop sharing their markup, or if a stylesheet starts loading from another server.
- The catalogue job is `continue-on-error`: a broken export does not block Docker release (it is after it anyway) and does not make a PR on 4cat-site

## Side note
- The page does loads its typefaces from Google Fonts. It's the same request 4CAT's own pages make, but means it is not 100% self contained.

## Also fixed along the way

- The header logo's `mask-image` carried a `for testing` override is pointing at `4cat.digitalmethods.net`, so every page fetched its logo from another server (not sure who was testing that).
- Catalogue icons now follow the `module-icon` convention, so the `brand-*` icons render instead of coming out blank. (This this was a half change on redesign branch.)

## Before merging

- Needs the `CATALOGUE_SITE_APP_ID` and `CATALOGUE_SITE_APP_PRIVATE_KEY` secrets (already added to 4CAT and tested).
- `docker_new_release.yml` will conflict when this eventually reaches master, which carries a smaller stub of the same change (to allow the manual Action runs). It can be replaced with this branch's file.